### PR TITLE
Improve mssql build to run general queries on start

### DIFF
--- a/mssql/Dockerfile
+++ b/mssql/Dockerfile
@@ -5,21 +5,40 @@
 # Base OS layer: Latest Ubuntu LTS
 FROM ubuntu:16.04
 
-#Install curl since it is needed to get repo config
+# Install curl since it is needed to get repo config
 # Get official Microsoft repository configuration
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
-    apt-get install -y curl && \
+    apt-get install -y curl locales && \
     apt-get install apt-transport-https && \
     curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
     curl https://packages.microsoft.com/config/ubuntu/16.04/mssql-server-2017.list | tee /etc/apt/sources.list.d/mssql-server.list && \
     apt-get update
 
 # Install SQL Server which a prerequisite for the optional packages below.
-RUN apt-get install -y mssql-server
+# Install full text search addons
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get install -y mssql-server mssql-server-ha mssql-server-fts
 
-RUN apt-get install -y mssql-server-ha
-RUN apt-get install -y mssql-server-fts
+# we need en_US locales for MSSQL connection to work
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    dpkg-reconfigure --frontend=noninteractive locales && \
+    update-locale LANG=en_US.UTF-8
+
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
+
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
+    curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list | tee /etc/apt/sources.list.d/msprod.list && \
+    apt-get update && \
+    ACCEPT_EULA=Y apt-get install -y msodbcsql mssql-tools unixodbc-dev
+
+RUN mkdir /custom
+COPY ./custom /custom/
+
+RUN chmod +x /custom/*.sh
 
 # Run SQL Server process
-CMD /opt/mssql/bin/sqlservr
+CMD /bin/bash /custom/entrypoint.sh

--- a/mssql/custom/entrypoint.sh
+++ b/mssql/custom/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# start SQL Server, start the script to create the DB and import the data, start the app
+/opt/mssql/bin/sqlservr & /custom/import-data.sh & tail -f /dev/null

--- a/mssql/custom/entrypoint.sh
+++ b/mssql/custom/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 # start SQL Server, start the script to create the DB and import the data, start the app
-/opt/mssql/bin/sqlservr & /custom/import-data.sh & tail -f /dev/null
+/opt/mssql/bin/sqlservr & /custom/setup.sh & tail -f /dev/null

--- a/mssql/custom/setup.sh
+++ b/mssql/custom/setup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# wait for the SQL Server to come up
+sleep 20s
+
+echo "Running initial SQL statements"
+
+# run the setup script to create the DB and the schema in the DB
+/opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P "$SA_PASSWORD" -d master -i /custom/setup.sql

--- a/mssql/custom/setup.sql
+++ b/mssql/custom/setup.sql
@@ -1,0 +1,4 @@
+EXEC sp_configure 'show advanced options', 1;
+RECONFIGURE;
+EXEC sp_configure 'clr strict security', 0;
+RECONFIGURE;


### PR DESCRIPTION
For Totara to create the necessary tables on a MSSQL database it need cls_strict_security set to 0. As this is a once-off setting to be made I've decided to add this to the mssql image so that the developer does not have to care about this setting anymore.

To allow this it needed a few adjustments.