### PR TITLE
Fix nginx upload limit

### DIFF
--- a/nginx/config/server.conf
+++ b/nginx/config/server.conf
@@ -31,3 +31,6 @@ location ~* ^.+.(jpg|jpeg|gif|css|png|js|ico|html|xml|txt)$ {
 
 gzip  on;
 gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript image/svg+xml;
+
+# increase nginx default upload size limit of 1MB
+client_max_body_size 1024M;


### PR DESCRIPTION
Fixes a bug with uploading files larger than 1MB giving a 403 error by increasing the limit to 1GB in the nginx config