### PR TITLE
Move copy of files to the end of the php dockerfile

### DIFF
--- a/php/php54/Dockerfile
+++ b/php/php54/Dockerfile
@@ -4,9 +4,6 @@ ARG TIME_ZONE=Pacific/Auckland
 
 ENV DEBIAN_FRONTEND noninteractive
 
-COPY config/php.ini /etc/php5/conf.d/99-php.ini
-COPY config/fpm.conf /etc/php5/fpm/pool.d/zz-totara.conf
-
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     tzdata \
     locales \
@@ -50,6 +47,9 @@ RUN sed -i 's/pm.max_children = 5/pm.max_children = 16/g' /etc/php5/fpm/pool.d/w
 
 RUN echo ${TIME_ZONE} > /etc/timezone \
     && dpkg-reconfigure --frontend noninteractive tzdata
+
+COPY config/php.ini /etc/php5/conf.d/99-php.ini
+COPY config/fpm.conf /etc/php5/fpm/pool.d/zz-totara.conf
 
 EXPOSE 9000
 

--- a/php/php55/Dockerfile
+++ b/php/php55/Dockerfile
@@ -4,9 +4,6 @@ ARG TIME_ZONE=Pacific/Auckland
 
 ENV DEBIAN_FRONTEND noninteractive
 
-COPY config/php.ini /etc/php5/conf.d/99-php.ini
-COPY config/fpm.conf /etc/php5/fpm/pool.d/zz-totara.conf
-
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     tzdata \
     locales \
@@ -55,6 +52,9 @@ RUN sed -i 's/pm.max_children = 5/pm.max_children = 16/g' /etc/php5/fpm/pool.d/w
 
 RUN echo ${TIME_ZONE} > /etc/timezone \
     && dpkg-reconfigure --frontend noninteractive tzdata
+
+COPY config/php.ini /etc/php5/conf.d/99-php.ini
+COPY config/fpm.conf /etc/php5/fpm/pool.d/zz-totara.conf
 
 EXPOSE 9000
 

--- a/php/php56/Dockerfile
+++ b/php/php56/Dockerfile
@@ -2,9 +2,6 @@ FROM php:5.6-fpm
 
 ARG TIME_ZONE=Pacific/Auckland
 
-COPY config/php.ini /usr/local/etc/php/php.ini
-COPY config/fpm.conf /usr/local/etc/php-fpm.d/zz-totara.conf
-
 RUN apt-get update && apt-get install -y \
         apt-transport-https \
         libfreetype6-dev \
@@ -69,3 +66,6 @@ RUN cd / && git clone https://github.com/wolfcw/libfaketime.git \
 
 RUN ln -fs /usr/share/zoneinfo/${TIME_ZONE} /etc/localtime \
     && dpkg-reconfigure --frontend noninteractive tzdata
+
+COPY config/php.ini /usr/local/etc/php/php.ini
+COPY config/fpm.conf /usr/local/etc/php-fpm.d/zz-totara.conf

--- a/php/php70/Dockerfile
+++ b/php/php70/Dockerfile
@@ -2,10 +2,6 @@ FROM php:7.0-fpm
 
 ARG TIME_ZONE=Pacific/Auckland
 
-COPY config/php.ini /usr/local/etc/php/
-COPY config/fpm.conf /usr/local/etc/php-fpm.d/zz-totara.conf
-
-
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         apt-transport-https \
         libfreetype6-dev \
@@ -76,3 +72,6 @@ RUN pear config-set php_ini `php --ini | grep "Loaded Configuration" | sed -e "s
 
 RUN ln -fs /usr/share/zoneinfo/${TIME_ZONE} /etc/localtime \
     && dpkg-reconfigure --frontend noninteractive tzdata
+
+COPY config/php.ini /usr/local/etc/php/
+COPY config/fpm.conf /usr/local/etc/php-fpm.d/zz-totara.conf

--- a/php/php71/Dockerfile
+++ b/php/php71/Dockerfile
@@ -2,9 +2,6 @@ FROM php:7.1-fpm
 
 ARG TIME_ZONE=Pacific/Auckland
 
-COPY config/php.ini /usr/local/etc/php/
-COPY config/fpm.conf /usr/local/etc/php-fpm.d/zz-totara.conf
-
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         apt-transport-https \
         libfreetype6-dev \
@@ -79,3 +76,5 @@ RUN pear config-set php_ini `php --ini | grep "Loaded Configuration" | sed -e "s
 RUN ln -fs /usr/share/zoneinfo/${TIME_ZONE} /etc/localtime \
     && dpkg-reconfigure --frontend noninteractive tzdata
 
+COPY config/php.ini /usr/local/etc/php/
+COPY config/fpm.conf /usr/local/etc/php-fpm.d/zz-totara.conf

--- a/php/php72/Dockerfile
+++ b/php/php72/Dockerfile
@@ -2,9 +2,6 @@ FROM php:7.2-fpm
 
 ARG TIME_ZONE=Pacific/Auckland
 
-COPY config/php.ini /usr/local/etc/php/
-COPY config/fpm.conf /usr/local/etc/php-fpm.d/zz-totara.conf
-
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         apt-transport-https \
         libfreetype6-dev \
@@ -78,3 +75,6 @@ RUN pear config-set php_ini `php --ini | grep "Loaded Configuration" | sed -e "s
 
 RUN ln -fs /usr/share/zoneinfo/${TIME_ZONE} /etc/localtime \
     && dpkg-reconfigure --frontend noninteractive tzdata
+
+COPY config/php.ini /usr/local/etc/php/
+COPY config/fpm.conf /usr/local/etc/php-fpm.d/zz-totara.conf

--- a/php/php73/Dockerfile
+++ b/php/php73/Dockerfile
@@ -2,9 +2,6 @@ FROM php:7.3-rc-fpm
 
 ARG TIME_ZONE=Pacific/Auckland
 
-COPY config/php.ini /usr/local/etc/php/
-COPY config/fpm.conf /usr/local/etc/php-fpm.d/zz-totara.conf
-
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         apt-transport-https \
         libfreetype6-dev \
@@ -79,3 +76,6 @@ RUN pear config-set php_ini `php --ini | grep "Loaded Configuration" | sed -e "s
 
 RUN ln -fs /usr/share/zoneinfo/${TIME_ZONE} /etc/localtime \
     && dpkg-reconfigure --frontend noninteractive tzdata
+
+COPY config/php.ini /usr/local/etc/php/
+COPY config/fpm.conf /usr/local/etc/php-fpm.d/zz-totara.conf


### PR DESCRIPTION
Currently if you change something in the php.ini or fpm config file for a PHP container you end up building the container from the very beginning on which is time consuming.

Having the copy commands at the end would result in quicker builds if you only change the config files