### PR TITLE
Fix enabling xdebug

### DIFF
--- a/php/php56-debug/Dockerfile
+++ b/php/php56-debug/Dockerfile
@@ -1,7 +1,6 @@
 FROM totara/docker-dev-php56:latest
 
-RUN pecl install -f xdebug-2.5.5
+RUN pecl install -f xdebug-2.5.5 && docker-php-ext-enable xdebug.so
 
-RUN echo "zend_extension=xdebug.so" >> /usr/local/etc/php/conf.d/xdebug.ini \
-    && echo "xdebug.remote_enable=on" >> /usr/local/etc/php/conf.d/xdebug.ini \
+RUN echo "xdebug.remote_enable=on" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.remote_autostart=off" >> /usr/local/etc/php/conf.d/xdebug.ini

--- a/php/php70-debug/Dockerfile
+++ b/php/php70-debug/Dockerfile
@@ -1,6 +1,6 @@
 FROM totara/docker-dev-php70:latest
 
-RUN pecl install -f xdebug
+RUN pecl install -f xdebug && docker-php-ext-enable xdebug.so
 
 RUN echo "xdebug.remote_enable=on" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.remote_autostart=off" >> /usr/local/etc/php/conf.d/xdebug.ini

--- a/php/php71-debug/Dockerfile
+++ b/php/php71-debug/Dockerfile
@@ -1,6 +1,6 @@
 FROM totara/docker-dev-php71:latest
 
-RUN pecl install -f xdebug
+RUN pecl install -f xdebug && docker-php-ext-enable xdebug.so
 
 RUN echo "xdebug.remote_enable=on" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.remote_autostart=off" >> /usr/local/etc/php/conf.d/xdebug.ini

--- a/php/php72-debug/Dockerfile
+++ b/php/php72-debug/Dockerfile
@@ -1,6 +1,6 @@
 FROM totara/docker-dev-php72:latest
 
-RUN pecl install -f xdebug
+RUN pecl install -f xdebug && docker-php-ext-enable xdebug.so
 
 RUN echo "xdebug.remote_enable=on" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.remote_autostart=off" >> /usr/local/etc/php/conf.d/xdebug.ini

--- a/php/php73-debug/Dockerfile
+++ b/php/php73-debug/Dockerfile
@@ -1,7 +1,6 @@
 FROM totara/docker-dev-php73:latest
 
-RUN pecl install -f xdebug-2.7.0beta1
+RUN pecl install -f xdebug-2.7.0beta1 && docker-php-ext-enable xdebug.so
 
-RUN echo "zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20180731/xdebug.so" >> /usr/local/etc/php/conf.d/xdebug.ini \
-    && echo "xdebug.remote_enable=on" >> /usr/local/etc/php/conf.d/xdebug.ini \
+RUN echo "xdebug.remote_enable=on" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.remote_autostart=off" >> /usr/local/etc/php/conf.d/xdebug.ini


### PR DESCRIPTION
Since last build the enabling of xdebug did not work on several PHP versions. So I've added an explicit enable call using the tool the PHP container itself provides (It is not available for PHP 5.4 and 5.5).