### PR TITLE
Add PostgreSQL 9.6, unify volume names, update pgsql support in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Although this project started as a development environment for Totara Learn it c
 ### What you get:
  * [NGINX](https://nginx.org/) as a webserver
  * [PHP](http://php.net/) 5.4, 5.5, 5.6, 7.0, 7.1, 7.2, 7.3 to test for different versions
- * [PostgreSQL](https://www.postgresql.org/) (9.3.x and 10.x), [MariaDB](https://mariadb.org/) (10.2.x) and [MySQL](https://www.mysql.com/) (5.7.x), and [Microsoft SQL Server 2017](https://www.microsoft.com/en-us/sql-server/sql-server-2017) support
+ * [PostgreSQL](https://www.postgresql.org/) (9.3, 9.6, 10, 11), [MariaDB](https://mariadb.org/) (10.2.x) and [MySQL](https://www.mysql.com/) (5.7.x), and [Microsoft SQL Server 2017](https://www.microsoft.com/en-us/sql-server/sql-server-2017) support
  * A [PHPUnit](https://phpunit.de/) and [Behat](http://behat.org/en/latest/) setup to run tests (including [Selenium](https://www.seleniumhq.org/))
  * A [mailcatcher](https://mailcatcher.me/) instance to inspect mails
  * [Redis](https://redis.io/) for caching and/or session handling

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -335,7 +335,7 @@ services:
     environment:
       PGDATA: /var/lib/postgresql/data/pgdata
     volumes:
-      - pgsql-data:/var/lib/postgresql/data
+      - pgsql-data11:/var/lib/postgresql/data
     depends_on:
      - nginx
     networks:
@@ -354,6 +354,20 @@ services:
      - nginx
     networks:
       - totara
+
+  pgsql96:
+    image: postgres:9.6
+    container_name: totara_pgsql96
+    ports:
+    - "5496:5432"
+    environment:
+      PGDATA: /var/lib/postgresql/data/pgdata
+    volumes:
+    - pgsql96-data:/var/lib/postgresql/data
+    depends_on:
+    - nginx
+    networks:
+    - totara
 
   pgsql93:
     image: postgres:9.3
@@ -487,9 +501,10 @@ services:
       - totara
 
 volumes:
-    pgsql-data:
-    pgsql10-data:
     pgsql93-data:
+    pgsql96-data:
+    pgsql10-data:
+    pgsql11-data:
     mssql-data:
     mysql-data:
     mysql80-data:


### PR DESCRIPTION
@samanthajayasinghe  I thought it might be better to put the version into the volume names even for the default pgsql container. With this is it will be easier in the future to add a new version without breaking the old version