### PR TITLE
Fix tdocker to work with docker-compose file refactor

### DIFF
--- a/bin/tdocker
+++ b/bin/tdocker
@@ -3,20 +3,13 @@
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 PROJECTPATH="$( cd $SCRIPTPATH && cd ..; pwd -P )"
 
-# if there's a docker-sync folder we assume that
-# the docker-sync configuration should be used
-if [ -d "$PROJECTPATH/.docker-sync" ]
-then
-    cd $PROJECTPATH; docker-compose \
-        -f docker-compose.yml \
-        -f compose/nginx.yml \
-        -f compose/mariadb.yml \
-        -f compose/mssql.yml \
-        -f compose/mysql.yml \
-        -f compose/pgsql.yml \
-        -f compose/php.yml \
-        -f compose/selenium.yml \
-        -f compose/sync.yml "$@"
-else
-    cd $PROJECTPATH; docker-compose "$@"
-fi
+cd $PROJECTPATH; docker-compose \
+    -f docker-compose.yml \
+    -f compose/nginx.yml \
+    -f compose/mariadb.yml \
+    -f compose/mssql.yml \
+    -f compose/mysql.yml \
+    -f compose/pgsql.yml \
+    -f compose/php.yml \
+    -f compose/selenium.yml \
+    -f compose/sync.yml "$@"


### PR DESCRIPTION
With Fabian's docker-compose file refactor, most of the docker images are no longer defined in the root docker-compose.yml. Docker-compose does not search sub directories for .yml's, so the tdocker command must always load all the yml's, otherwise trying to up/down containers defined outside of docker-compose.yml will return a "No such service" error.