### PR TITLE
Fix max_locks_per_transaction behat error with postgres

### DIFF
--- a/compose/pgsql.yml
+++ b/compose/pgsql.yml
@@ -6,6 +6,10 @@ services:
     container_name: totara_pgsql93
     ports:
     - "5493:5432"
+    command:
+      postgres
+      -c max_locks_per_transaction=1024
+      -c max_pred_locks_per_transaction=1024
     environment:
       PGDATA: /var/lib/postgresql/data/pgdata
     volumes:
@@ -20,6 +24,10 @@ services:
     container_name: totara_pgsql96
     ports:
     - "5496:5432"
+    command:
+      postgres
+      -c max_locks_per_transaction=1024
+      -c max_pred_locks_per_transaction=1024
     environment:
       PGDATA: /var/lib/postgresql/data/pgdata
     volumes:
@@ -34,6 +42,10 @@ services:
     container_name: totara_pgsql10
     ports:
     - "5410:5432"
+    command:
+      postgres
+      -c max_locks_per_transaction=1024
+      -c max_pred_locks_per_transaction=1024
     environment:
       PGDATA: /var/lib/postgresql/data/pgdata
     volumes:
@@ -48,6 +60,10 @@ services:
     container_name: totara_pgsql11
     ports:
     - "5432:5432"
+    command:
+      postgres
+      -c max_locks_per_transaction=1024
+      -c max_pred_locks_per_transaction=1024
     environment:
       PGDATA: /var/lib/postgresql/data/pgdata
     volumes:


### PR DESCRIPTION
When installing behat in parallel on postgres, it returns a 'out of shared memory' exception, caused by a limit of 64 max locks per transaction. I found this to occur on Totara 10 and 13, and on postgres 11.1 and 9.3. I've increased it to 1024 locks per transaction for all postgres versions, which fixes the issue.