### PR TITLE
Increase nginx cgi buffer size to allow larger error messages

### DIFF
--- a/nginx/config/server.conf
+++ b/nginx/config/server.conf
@@ -21,6 +21,8 @@ location ~ [^/]\.php(/|$) {
     fastcgi_index index.php;
     fastcgi_param SCRIPT_FILENAME $document_root/$fastcgi_script_name;
     fastcgi_param PATH_INFO       $fastcgi_path_info;
+    fastcgi_buffers 16 16k;
+    fastcgi_buffer_size 32k;
 }
 
 # serve static files directly


### PR DESCRIPTION
Fixes an issue where some error messages were hitting the cgi buffer limit and would cause a 502 Bad Gateway error instead of gracefully returning the error message