### PR TITLE
Add debug hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Although this project started as a development environment for Totara Learn it c
 
 __Example:__
 ```bash
-127.0.0.1   localhost totara54 totara54.behat totara55 totara55.behat totara56 totara56.behat totara70 totara70.behat totara71 totara71.behat totara72 totara72.behat totara73 totara73.behat
+127.0.0.1   localhost totara54 totara54.debug totara54.behat totara55 totara55.debug totara55.behat totara55 totara55.debug totara56.behat totara70 totara70.debug totara70.behat totara71 totara71.debug totara71.behat totara72 totara72.debug totara72.behat totara73 totara73.debug totara73.behat
 ```
 
 ## Use

--- a/compose/nginx.yml
+++ b/compose/nginx.yml
@@ -18,24 +18,31 @@ services:
       totara:
         aliases:
         - totara54
+        - totara54.debug
         - totara54.behat
         - totara54.behat.totaralms.com
         - totara55
+        - totara55.debug
         - totara55.behat
         - totara55.behat.totaralms.com
         - totara56
+        - totara56.debug
         - totara56.behat
         - totara56.behat.totaralms.com
         - totara70
+        - totara70.debug
         - totara70.behat
         - totara70.behat.totaralms.com
         - totara71
+        - totara71.debug
         - totara71.behat
         - totara71.behat.totaralms.com
         - totara72
+        - totara72.debug
         - totara72.behat
         - totara72.behat.totaralms.com
         - totara73
+        - totara73.debug
         - totara73.behat
         - totara73.behat.totaralms.com
 

--- a/nginx/config/totara.conf
+++ b/nginx/config/totara.conf
@@ -55,7 +55,7 @@ server {
 
 server {
     server_name totara70;
-    set $upstream php-7.0-debug;
+    set $upstream php-7.0;
     include totara-server.conf;
 }
 
@@ -73,7 +73,7 @@ server {
 
 server {
     server_name totara71;
-    set $upstream php-7.1-debug;
+    set $upstream php-7.1;
     include totara-server.conf;
 }
 

--- a/nginx/config/totara.conf
+++ b/nginx/config/totara.conf
@@ -1,6 +1,12 @@
 
 server {
     server_name totara54;
+    set $upstream php-5.4;
+    include totara-server.conf;
+}
+
+server {
+    server_name totara54.debug;
     set $upstream php-5.4-debug;
     include totara-server.conf;
 }
@@ -13,6 +19,12 @@ server {
 
 server {
     server_name totara55;
+    set $upstream php-5.5;
+    include totara-server.conf;
+}
+
+server {
+    server_name totara55.debug;
     set $upstream php-5.5-debug;
     include totara-server.conf;
 }
@@ -25,6 +37,12 @@ server {
 
 server {
     server_name totara56;
+    set $upstream php-5.6;
+    include totara-server.conf;
+}
+
+server {
+    server_name totara56.debug;
     set $upstream php-5.6-debug;
     include totara-server.conf;
 }
@@ -42,6 +60,12 @@ server {
 }
 
 server {
+    server_name totara70.debug;
+    set $upstream php-7.0-debug;
+    include totara-server.conf;
+}
+
+server {
     server_name totara70.behat;
     set $upstream php-7.0;
     include totara-server.conf;
@@ -54,6 +78,12 @@ server {
 }
 
 server {
+    server_name totara71.debug;
+    set $upstream php-7.1-debug;
+    include totara-server.conf;
+}
+
+server {
     server_name totara71.behat;
     set $upstream php-7.1;
     include totara-server.conf;
@@ -61,6 +91,12 @@ server {
 
 server {
     server_name totara72;
+    set $upstream php-7.2;
+    include totara-server.conf;
+}
+
+server {
+    server_name totara72.debug;
     set $upstream php-7.2-debug;
     include totara-server.conf;
 }
@@ -73,6 +109,12 @@ server {
 
 server {
     server_name totara73;
+    set $upstream php-7.3;
+    include totara-server.conf;
+}
+
+server {
+    server_name totara73.debug;
     set $upstream php-7.3-debug;
     include totara-server.conf;
 }

--- a/php/php56-debug/Dockerfile
+++ b/php/php56-debug/Dockerfile
@@ -2,5 +2,5 @@ FROM totara/docker-dev-php56:latest
 
 RUN pecl install -f xdebug-2.5.5 && docker-php-ext-enable xdebug.so
 
-RUN echo "xdebug.remote_enable=on" >> /usr/local/etc/php/conf.d/xdebug.ini \
-    && echo "xdebug.remote_autostart=off" >> /usr/local/etc/php/conf.d/xdebug.ini
+RUN echo "xdebug.remote_enable=1" >> /usr/local/etc/php/conf.d/xdebug.ini \
+    && echo "xdebug.remote_autostart=0" >> /usr/local/etc/php/conf.d/xdebug.ini

--- a/php/php70-debug/Dockerfile
+++ b/php/php70-debug/Dockerfile
@@ -2,5 +2,5 @@ FROM totara/docker-dev-php70:latest
 
 RUN pecl install -f xdebug && docker-php-ext-enable xdebug.so
 
-RUN echo "xdebug.remote_enable=on" >> /usr/local/etc/php/conf.d/xdebug.ini \
-    && echo "xdebug.remote_autostart=off" >> /usr/local/etc/php/conf.d/xdebug.ini
+RUN echo "xdebug.remote_enable=1" >> /usr/local/etc/php/conf.d/xdebug.ini \
+    && echo "xdebug.remote_autostart=0" >> /usr/local/etc/php/conf.d/xdebug.ini

--- a/php/php71-debug/Dockerfile
+++ b/php/php71-debug/Dockerfile
@@ -2,5 +2,5 @@ FROM totara/docker-dev-php71:latest
 
 RUN pecl install -f xdebug && docker-php-ext-enable xdebug.so
 
-RUN echo "xdebug.remote_enable=on" >> /usr/local/etc/php/conf.d/xdebug.ini \
-    && echo "xdebug.remote_autostart=off" >> /usr/local/etc/php/conf.d/xdebug.ini
+RUN echo "xdebug.remote_enable=1" >> /usr/local/etc/php/conf.d/xdebug.ini \
+    && echo "xdebug.remote_autostart=0" >> /usr/local/etc/php/conf.d/xdebug.ini

--- a/php/php72-debug/Dockerfile
+++ b/php/php72-debug/Dockerfile
@@ -2,5 +2,5 @@ FROM totara/docker-dev-php72:latest
 
 RUN pecl install -f xdebug && docker-php-ext-enable xdebug.so
 
-RUN echo "xdebug.remote_enable=on" >> /usr/local/etc/php/conf.d/xdebug.ini \
-    && echo "xdebug.remote_autostart=off" >> /usr/local/etc/php/conf.d/xdebug.ini
+RUN echo "xdebug.remote_enable=1" >> /usr/local/etc/php/conf.d/xdebug.ini \
+    && echo "xdebug.remote_autostart=0" >> /usr/local/etc/php/conf.d/xdebug.ini

--- a/php/php73-debug/Dockerfile
+++ b/php/php73-debug/Dockerfile
@@ -2,5 +2,5 @@ FROM totara/docker-dev-php73:latest
 
 RUN pecl install -f xdebug-2.7.0beta1 && docker-php-ext-enable xdebug.so
 
-RUN echo "xdebug.remote_enable=on" >> /usr/local/etc/php/conf.d/xdebug.ini \
-    && echo "xdebug.remote_autostart=off" >> /usr/local/etc/php/conf.d/xdebug.ini
+RUN echo "xdebug.remote_enable=1" >> /usr/local/etc/php/conf.d/xdebug.ini \
+    && echo "xdebug.remote_autostart=0" >> /usr/local/etc/php/conf.d/xdebug.ini


### PR DESCRIPTION
Currently the normal hosts always have xdebug enable which slows down the site a lot.
To be able to distinguish between a non-xdebug and a xdebug host I've split those up.

Note: You need to update you /etc/hosts file.