### PR TITLE
Allow specifying bash aliases for use in the php containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .env
 !.gitkeep
 /cron.d/*.cron
+/bash/*.bash

--- a/README.md
+++ b/README.md
@@ -435,3 +435,8 @@ You can use the session id or any part of the paths to monitor the session, for 
 ```bash
 mutagen monitor totara
 ```
+
+## Custom bash aliases
+
+The `bash` folder lets you add custom aliases and functions to your php containers. Any file with the `.bash` extension will be sourced into your php container whenever you bash into it. This is useful for when you need to run complex commands often during development, such as initialising tests. To get started, simply copy `aliases.bash.dist` to `aliases.bash` and define your aliases.
+ 

--- a/bash/.gitkeep
+++ b/bash/.gitkeep
@@ -1,0 +1,1 @@
+# Add any .bash file or multiple .bash files with your scripts here in this folder for them to be sourced into the php containers

--- a/bash/aliases.bash.dist
+++ b/bash/aliases.bash.dist
@@ -1,0 +1,22 @@
+# You can use these aliases as a template, just copy/rename this file to aliases.bash
+
+# Perform a fresh install of Totara
+alias install='php admin/cli/install_database.php --adminpass=admin --adminemail=admin@totara.local --agree-license --fullname=Totara\ 13\ Dev --shortname=t13-dev'
+
+# Initialise PHPUnit
+alias installunit='php admin/tool/phpunit/cli/init.php'
+
+# Initialise Behat
+alias installbehat='php admin/tool/behat/cli/init.php'
+
+# Run PhpUnit
+alias unit='vendor/bin/phpunit --test-suffix="test.php" '
+
+# Run Behat
+alias behat='vendor/bin/behat '
+
+# Run cron
+alias cron='php admin/cli/cron.php'
+
+# Create a test course
+alias createcourse='php admin/tool/generator/cli/maketestcourse.php --shortname=course --size=S'

--- a/compose/php.yml
+++ b/compose/php.yml
@@ -11,6 +11,7 @@ services:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
       - $HOME/.bash_history:/root/.bash_history
+      - ./bash:/root/custom_bash
     depends_on:
       - php-5.4-debug
     networks:
@@ -28,6 +29,7 @@ services:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
       - $HOME/.bash_history:/root/.bash_history
+      - ./bash:/root/custom_bash
     networks:
       - totara
 
@@ -51,6 +53,7 @@ services:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
       - $HOME/.bash_history:/root/.bash_history
+      - ./bash:/root/custom_bash
     depends_on:
       - php-5.5-debug
     networks:
@@ -68,6 +71,7 @@ services:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
       - $HOME/.bash_history:/root/.bash_history
+      - ./bash:/root/custom_bash
     networks:
       - totara
 
@@ -91,6 +95,7 @@ services:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
       - $HOME/.bash_history:/root/.bash_history
+      - ./bash:/root/custom_bash
     depends_on:
       - php-5.6-debug
     networks:
@@ -108,6 +113,7 @@ services:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
       - $HOME/.bash_history:/root/.bash_history
+      - ./bash:/root/custom_bash
     networks:
       - totara
 
@@ -131,6 +137,7 @@ services:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
       - $HOME/.bash_history:/root/.bash_history
+      - ./bash:/root/custom_bash
     depends_on:
       - php-7.0-debug
     networks:
@@ -148,6 +155,7 @@ services:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
       - $HOME/.bash_history:/root/.bash_history
+      - ./bash:/root/custom_bash
     networks:
       - totara
 
@@ -171,6 +179,7 @@ services:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
       - $HOME/.bash_history:/root/.bash_history
+      - ./bash:/root/custom_bash
     depends_on:
       - php-7.1-debug
     networks:
@@ -188,6 +197,7 @@ services:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
       - $HOME/.bash_history:/root/.bash_history
+      - ./bash:/root/custom_bash
     networks:
       - totara
 
@@ -211,6 +221,7 @@ services:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
       - $HOME/.bash_history:/root/.bash_history
+      - ./bash:/root/custom_bash
     depends_on:
       - php-7.2-debug
     networks:
@@ -228,6 +239,7 @@ services:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
       - $HOME/.bash_history:/root/.bash_history
+      - ./bash:/root/custom_bash
     networks:
       - totara
 
@@ -251,6 +263,7 @@ services:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
       - $HOME/.bash_history:/root/.bash_history
+      - ./bash:/root/custom_bash
     depends_on:
       - php-7.3-debug
     networks:
@@ -268,6 +281,7 @@ services:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
       - $HOME/.bash_history:/root/.bash_history
+      - ./bash:/root/custom_bash
     networks:
       - totara
 

--- a/php/php54/Dockerfile
+++ b/php/php54/Dockerfile
@@ -91,6 +91,9 @@ COPY config/php.ini /tmp/php.ini
 RUN cat /tmp/php.ini >> /usr/local/php/lib/php.ini
 COPY config/fpm.conf /usr/local/php/etc/php-fpm.d/zz-totara.conf
 
+# Source each .bash file found in the /bash/ folder
+RUN echo 'for f in ~/custom_bash/*.bash; do [[ -e "$f" ]] && source "$f"; done;' >> ~/.bashrc
+
 EXPOSE 9000
 
 CMD ["/usr/local/php/sbin/php-fpm", "-F"]

--- a/php/php55/Dockerfile
+++ b/php/php55/Dockerfile
@@ -91,6 +91,9 @@ COPY config/php.ini /tmp/php.ini
 RUN cat /tmp/php.ini >> /usr/local/php/lib/php.ini
 COPY config/fpm.conf /usr/local/php/etc/php-fpm.d/zz-totara.conf
 
+# Source each .bash file found in the /bash/ folder
+RUN echo 'for f in ~/custom_bash/*.bash; do [[ -e "$f" ]] && source "$f"; done;' >> ~/.bashrc
+
 EXPOSE 9000
 
 CMD ["/usr/local/php/sbin/php-fpm", "-F"]

--- a/php/php56/Dockerfile
+++ b/php/php56/Dockerfile
@@ -69,3 +69,6 @@ RUN ln -fs /usr/share/zoneinfo/${TIME_ZONE} /etc/localtime \
 
 COPY config/php.ini /usr/local/etc/php/php.ini
 COPY config/fpm.conf /usr/local/etc/php-fpm.d/zz-totara.conf
+
+# Source each .bash file found in the /bash/ folder
+RUN echo 'for f in ~/custom_bash/*.bash; do [[ -e "$f" ]] && source "$f"; done;' >> ~/.bashrc

--- a/php/php70/Dockerfile
+++ b/php/php70/Dockerfile
@@ -83,3 +83,6 @@ RUN ln -fs /usr/share/zoneinfo/${TIME_ZONE} /etc/localtime \
 
 COPY config/php.ini /usr/local/etc/php/
 COPY config/fpm.conf /usr/local/etc/php-fpm.d/zz-totara.conf
+
+# Source each .bash file found in the /bash/ folder
+RUN echo 'for f in ~/custom_bash/*.bash; do [[ -e "$f" ]] && source "$f"; done;' >> ~/.bashrc

--- a/php/php71/Dockerfile
+++ b/php/php71/Dockerfile
@@ -80,3 +80,6 @@ RUN ln -fs /usr/share/zoneinfo/${TIME_ZONE} /etc/localtime \
 
 COPY config/php.ini /usr/local/etc/php/
 COPY config/fpm.conf /usr/local/etc/php-fpm.d/zz-totara.conf
+
+# Source each .bash file found in the /bash/ folder
+RUN echo 'for f in ~/custom_bash/*.bash; do [[ -e "$f" ]] && source "$f"; done;' >> ~/.bashrc

--- a/php/php72/Dockerfile
+++ b/php/php72/Dockerfile
@@ -80,3 +80,6 @@ RUN ln -fs /usr/share/zoneinfo/${TIME_ZONE} /etc/localtime \
 
 COPY config/php.ini /usr/local/etc/php/
 COPY config/fpm.conf /usr/local/etc/php-fpm.d/zz-totara.conf
+
+# Source each .bash file found in the /bash/ folder
+RUN echo 'for f in ~/custom_bash/*.bash; do [[ -e "$f" ]] && source "$f"; done;' >> ~/.bashrc

--- a/php/php73/Dockerfile
+++ b/php/php73/Dockerfile
@@ -81,3 +81,6 @@ RUN ln -fs /usr/share/zoneinfo/${TIME_ZONE} /etc/localtime \
 
 COPY config/php.ini /usr/local/etc/php/
 COPY config/fpm.conf /usr/local/etc/php-fpm.d/zz-totara.conf
+
+# Source each .bash file found in the /bash/ folder
+RUN echo 'for f in ~/custom_bash/*.bash; do [[ -e "$f" ]] && source "$f"; done;' >> ~/.bashrc


### PR DESCRIPTION
What this does is allow the dev to add `.bash` files inside the `bash` folder that get sourced into the php containers whenever they are tbashed into. The way I've implemented it is nice as you don't need to rebuild or restart the containers when you make changes, instead you just need to exit the container and go back into it. It comes with some predefined aliases in the .aliases.bash.dist file which the dev may find useful.