### PR TITLE
Provide a script to easily pull the latest images

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,21 @@ __Example:__
 127.0.0.1   localhost totara54 totara54.debug totara54.behat totara55 totara55.debug totara55.behat totara55 totara55.debug totara56.behat totara70 totara70.debug totara70.behat totara71 totara71.debug totara71.behat totara72 totara72.debug totara72.behat totara73 totara73.debug totara73.behat
 ```
 
+## Update
+If you are already using the docker setup but you want to make sure you get the latest changes and features:
+1. make sure you pull the latest code from this repository
+1. and use the `tpull` script in the bin/ folder to pull the latest images
+
+```bash
+tpull [all]   # updates all images already present locally by pulling the latest changes from docker hub
+tpull nginx   # to update a specific image use the last part of the repository name, for example nginx resolves to docker-dev-nginx
+tpull php73
+```
+
+If you pull images from containers which currently running don't forget to run `tup` on them so that the latest image is used.
+
+Alternatively to pulling the pre-built images you can also rebuild themselve by using `tbuild [container]`, for example `tbuild php-7.3`. Please note that rebuilding the images can take a while.
+
 ## Performance
 
 To speed up performance you can use a sync tool called mutagen. 

--- a/README.md
+++ b/README.md
@@ -61,14 +61,13 @@ __Example:__
 If you are already using the docker setup but you want to make sure you get the latest changes and features:
 1. make sure you pull the latest code from this repository
 1. and use the `tpull` script in the bin/ folder to pull the latest images
+1. `tup` any alreay running containers to apply changes
 
 ```bash
 tpull [all]   # updates all images already present locally by pulling the latest changes from docker hub
 tpull nginx   # to update a specific image use the last part of the repository name, for example nginx resolves to docker-dev-nginx
 tpull php73
 ```
-
-If you pull images from containers which currently running don't forget to run `tup` on them so that the latest image is used.
 
 Alternatively to pulling the pre-built images you can also rebuild themselve by using `tbuild [container]`, for example `tbuild php-7.3`. Please note that rebuilding the images can take a while.
 

--- a/bin/tpull
+++ b/bin/tpull
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [ $# -eq 0 ] || [ $1 == 'all' ]
+  then
+    # pulling all images already present from docker hub
+    docker images --filter=reference='totara/docker-dev-*' --format "{{.Repository}}" | xargs -I % sh -c 'docker pull %'
+else
+    # pull a specific image by providing only the last part of the repository name, like 'nginx' or 'php73'
+    docker pull docker-dev-$1
+fi
+


### PR DESCRIPTION
To make it easier to pull the latest images I created a bash script

Usage:
`tpull all` - pulls all images which are already there locally
`tpull [image]` - for example `tpull php73` pulls just this one image (docker-dev-php73)