### PR TITLE
Use tdocker inside of tbuild

### DIFF
--- a/bin/tbuild
+++ b/bin/tbuild
@@ -3,14 +3,4 @@
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 PROJECTPATH="$( cd $SCRIPTPATH && cd ..; pwd -P )"
 
-cd $PROJECTPATH && docker-compose \
-    -f docker-compose.yml \
-    -f compose/nginx.yml \
-    -f compose/mariadb.yml \
-    -f compose/mssql.yml \
-    -f compose/mysql.yml \
-    -f compose/pgsql.yml \
-    -f compose/php.yml \
-    -f compose/selenium.yml \
-    -f compose/build.yml \
-    build "$@"
+$SCRIPTPATH/tdocker build "$@"

--- a/bin/tdocker
+++ b/bin/tdocker
@@ -16,7 +16,11 @@ files=(
     "compose/selenium.yml"
 )
 
-if [ -f "$PROJECTPATH/.use-mutagen" ]; then
+if [[ "$1" -eq  "build" ]]; then
+    files+=(
+        "compose/build.yml"
+    )
+elif [[ -f "$PROJECTPATH/.use-mutagen" ]]; then
     files+=(
         "compose/sync.yml"
     )


### PR DESCRIPTION
A small improvement: instead of tbuild using docker-compose directly use tdocker to get support for building custom services. 