### PR TITLE
Add a proper timeout before mssql server starts

### DIFF
--- a/mssql/custom/setup.sh
+++ b/mssql/custom/setup.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 
-# wait for the SQL Server to come up
-sleep 20s
+# The SQL server won't start by this time, so let's gently wait for it, if it won't start in 120 sec, let's fail anyway.
+timeout=$(($(date +%s) + 120))
+until /opt/mssql-tools/bin/sqlcmd -H localhost -U sa -P "$SA_PASSWORD" -Q "select 'hello'" 2>/dev/null || [[ $(date +%s) -gt $timeout ]]; do
+  echo 'SQL server is not ready yet, sleeping for 2 seconds...'
+  sleep 2
+done
 
 echo "Running initial SQL statements"
 


### PR DESCRIPTION
Current static timeout is not sufficient on every system and causes some unexpected errors. This one will have a proper timeout up to 90 secs, which can be extended.