### PR TITLE
Fix php-7.1, php-7.2, php-7.3 containers build

### DIFF
--- a/php/php71/Dockerfile
+++ b/php/php71/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         pdo_mysql \
         pgsql \
         mysqli \
-    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+    && docker-php-ext-configure gd \
     && docker-php-ext-install -j$(nproc) gd
 
 RUN git clone https://github.com/tideways/php-profiler-extension.git \
@@ -57,7 +57,7 @@ ENV LC_ALL en_US.UTF-8
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
     && curl https://packages.microsoft.com/config/debian/8/prod.list | tee /etc/apt/sources.list.d/mssql-tools.list \
     && apt-get update && ACCEPT_EULA=Y apt-get install -y \
-    msodbcsql \
+    msodbcsql17 \
     mssql-tools \
     unixodbc-dev
 

--- a/php/php72/Dockerfile
+++ b/php/php72/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         pdo_mysql \
         pgsql \
         mysqli \
-    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+    && docker-php-ext-configure gd \
     && docker-php-ext-install -j$(nproc) gd
 
 RUN git clone https://github.com/tideways/php-profiler-extension.git \
@@ -57,7 +57,7 @@ ENV LC_ALL en_US.UTF-8
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
     && curl https://packages.microsoft.com/config/debian/8/prod.list | tee /etc/apt/sources.list.d/mssql-tools.list \
     && apt-get update && ACCEPT_EULA=Y apt-get install -y \
-    msodbcsql \
+    msodbcsql17 \
     mssql-tools \
     unixodbc-dev
 

--- a/php/php73/Dockerfile
+++ b/php/php73/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         pdo_mysql \
         pgsql \
         mysqli \
-    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+    && docker-php-ext-configure gd \
     && docker-php-ext-install -j$(nproc) gd
 
 RUN git clone https://github.com/tideways/php-profiler-extension.git \
@@ -58,7 +58,7 @@ ENV LC_ALL en_US.UTF-8
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
     && curl https://packages.microsoft.com/config/debian/8/prod.list | tee /etc/apt/sources.list.d/mssql-tools.list \
     && apt-get update && ACCEPT_EULA=Y apt-get install -y \
-    msodbcsql \
+    msodbcsql17 \
     mssql-tools \
     unixodbc-dev
 


### PR DESCRIPTION
I use a similar script to build php containers for behat, however tried to rebuild php7.1 container and id didn't build giving me an error when configuring gd, removing the given attributes fixed the problem.

Then the next problem popped up, so following https://docs.microsoft.com/en-us/sql/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server?view=sql-server-2017 specifying the version solved is as well.

To test cd to each affected php container folder and run docker build.