### PR TITLE
Fix redis version for PHP 5.6

### DIFF
--- a/php/php56/Dockerfile
+++ b/php/php56/Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get update && apt-get install -y \
 RUN pecl install xhprof-0.9.4 \
     && docker-php-ext-enable xhprof
 
-RUN pecl install -o -f redis \
+RUN pecl install -o -f redis-4.3.0 \
     &&  rm -rf /tmp/pear \
     &&  docker-php-ext-enable redis
 


### PR DESCRIPTION
The new version of the redis plugin (5.x) does require minimum PHP 7. Setting the version to the latest version with PHP 5 support.