### PR TITLE
Fix deprecated php.ini commenting

### DIFF
--- a/php/php56/config/php.ini
+++ b/php/php56/config/php.ini
@@ -5,8 +5,8 @@ always_populate_raw_post_data = -1
 max_input_vars = 2000
 date.timezone = Pacific/Auckland
 memory_limit=256M
-# necessary as Xdebug impacts performance that hard
+; necessary as Xdebug impacts performance that hard
 max_execution_time=120
-# relax file upload limits
+; relax file upload limits
 post_max_size = 64M
 upload_max_filesize = 64M

--- a/php/php70/config/php.ini
+++ b/php/php70/config/php.ini
@@ -4,7 +4,7 @@ error_reporting = E_ALL & ~E_DEPRECATED
 max_input_vars = 2000
 date.timezone = Pacific/Auckland
 memory_limit=256M
-# necessary as Xdebug impacts performance that hard
+; necessary as Xdebug impacts performance that hard
 max_execution_time=120
 ;opcache.revalidate_freq=0
 ;opcache.validate_timestamps=0 (comment this out in your dev environment)
@@ -12,6 +12,6 @@ max_execution_time=120
 ;opcache.memory_consumption=192
 ;opcache.interned_strings_buffer=16
 ;opcache.fast_shutdown=1
-# relax file upload limits
+; relax file upload limits
 post_max_size = 64M
 upload_max_filesize = 64M

--- a/php/php71/config/php.ini
+++ b/php/php71/config/php.ini
@@ -4,7 +4,7 @@ error_reporting = E_ALL & ~E_DEPRECATED
 max_input_vars = 2000
 date.timezone = Pacific/Auckland
 memory_limit=256M
-# necessary as Xdebug impacts performance that hard
+; necessary as Xdebug impacts performance that hard
 max_execution_time=120
 ;opcache.revalidate_freq=0
 ;opcache.validate_timestamps=0 (comment this out in your dev environment)
@@ -12,6 +12,6 @@ max_execution_time=120
 ;opcache.memory_consumption=192
 ;opcache.interned_strings_buffer=16
 ;opcache.fast_shutdown=1
-# relax file upload limits
+; relax file upload limits
 post_max_size = 64M
 upload_max_filesize = 64M

--- a/php/php72/config/php.ini
+++ b/php/php72/config/php.ini
@@ -4,7 +4,7 @@ error_reporting = E_ALL & ~E_DEPRECATED
 max_input_vars = 2000
 date.timezone = Pacific/Auckland
 memory_limit=256M
-# necessary as Xdebug impacts performance that hard
+; necessary as Xdebug impacts performance that hard
 max_execution_time=120
 ;opcache.revalidate_freq=0
 ;opcache.validate_timestamps=0 (comment this out in your dev environment)
@@ -12,6 +12,6 @@ max_execution_time=120
 ;opcache.memory_consumption=192
 ;opcache.interned_strings_buffer=16
 ;opcache.fast_shutdown=1
-# relax file upload limits
+; relax file upload limits
 post_max_size = 64M
 upload_max_filesize = 64M

--- a/php/php73/config/php.ini
+++ b/php/php73/config/php.ini
@@ -5,7 +5,7 @@ max_input_vars = 2000
 date.timezone = Pacific/Auckland
 memory_limit=256M
 opcache.optimization_level=0x7FFFBBFF
-# necessary as Xdebug impacts performance that hard
+; necessary as Xdebug impacts performance that hard
 max_execution_time=120
 ;opcache.revalidate_freq=0
 ;opcache.validate_timestamps=0 (comment this out in your dev environment)
@@ -13,6 +13,6 @@ max_execution_time=120
 ;opcache.memory_consumption=192
 ;opcache.interned_strings_buffer=16
 ;opcache.fast_shutdown=1
-# relax file upload limits
+; relax file upload limits
 post_max_size = 64M
 upload_max_filesize = 64M


### PR DESCRIPTION
I get these error messages all over the place:
`PHP Deprecated:  Comments starting with '#' are deprecated in /usr/local/etc/php/php.ini on line 10 in Unknown on line 0` 