### PR TITLE
Downgrade npm version to 5.6.0 to be compatible with CI system

### DIFF
--- a/compose/build.yml
+++ b/compose/build.yml
@@ -1,6 +1,9 @@
 version: "2"
 services:
 
+  nodejs:
+    build: ./nodejs
+
   nginx:
     build: ./nginx
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
   # docker-compose -f docker-compose.yml -f compose/nginx.yml -f compose/pgsql.yml -f compose/php.yml up -d pgsql php-7.3
 
   nodejs:
-    image: node:8
+    image: totara/docker-dev-nodejs
     container_name: totara_nodejs
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}

--- a/nodejs/Dockerfile
+++ b/nodejs/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:8
+
+RUN npm install -g npm@5.6.0
+
+CMD [ "node" ]
+


### PR DESCRIPTION
Currently the package-lock.json file is built with a lower npm version than the latest one in the docker image. The lock file generated by npm version 6 differs from the old version.

This downgrades it to version 5.6.0 which is the same version used in our CI systems.

This ensures the CI system does not fail builds until we are able to update Jenkins to the newer npm version as well.