### PR TITLE
Add tnpm command

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,24 @@ If needed, modify the local port in the docker-compose.yml file.
 
 ## NodeJS, NPM and grunt 
 
-If you want to use grunt or npm you can log into the nodejs container and issue the commands there:
+If you want to use npm you can use ```tnpm``` like this:
+```bash
+# if your project lives in a subfolder then run the command from inside that folder
+tnpm install
+tnpm run tui-dev
+tnpm run tui-watch
+```
+
+If you want to use grunt you can use ```tgrunt``` like this:
+```bash
+tgrunt
+# if your project lives in the subfolder 13 then run
+tgrunt 13
+# if you want to run a specific grunt task
+tgrunt 13 gherkinlint
+``` 
+
+Or alternativley you can just directly log in to the container directly run node/grunt commands:
 
 ```bash
 tdocker run nodejs bash
@@ -379,17 +396,6 @@ npm install
 npm install grunt-cli
 ./node_modules/.bin/grunt
 ```
-
-Or you use the shortcut bash script:
-
-```bash
-tgrunt
-# if your project lives in the subfolder 13 then run
-tgrunt 13
-# if you want to run a specific grunt task
-tgrunt 13 gherkinlint
-
-``` 
 
 ## mutagen
 

--- a/bin/tnpm
+++ b/bin/tnpm
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+PROJECTPATH="$( cd $SCRIPTPATH && cd ..; pwd -P )"
+
+export $(egrep -v '^#' $PROJECTPATH/.env | xargs)
+
+# If tnpm is called from a subdirectory, then we run npm in that subdirectory too
+[[ "$PWD" =~ ^$LOCAL_SRC/(.*)$ ]]
+TOTARASITEDIR="$REMOTE_SRC/${BASH_REMATCH[1]}"
+
+$SCRIPTPATH/tdocker run -w "$TOTARASITEDIR" nodejs npm "$@"


### PR DESCRIPTION
Added `tnpm` command, which works in a similar way to tgrunt/the other 't' commands.

It has the advantage of being used almost identical to regular npm commands, e.g. instead of running `npm run tui-dev`, you can run `tnpm run tui-dev`. This makes it easier to run npm commands listed in testing instructions/documentation, since you only need to prefix the command with a 't' at the beginning.

This command also is compatible with totara docker setups that use sub-directories - if you have multiple installations under a single LOCAL_SRC and you run `tnpm` from the installation folder, then it will run npm for that site.