### PR TITLE
Upgrade compose version and use name for network

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -7,7 +7,7 @@ MYSQL_ROOT_PW=root
 MSSQL_SA_PW=Totara.Mssql1
 # set this to your local IP address
 # for mac just use "host.docker.internal"
-# for linux run command "docker run --rm alpine ip -4 route list match 0/0 | cut -d' ' -f3" and use the resulting ip address
+# for linux run command "docker run --rm --network=totara alpine ip -4 route list match 0/0 | cut -d' ' -f3" and use the resulting ip address
 # most probably it is 172.17.0.1
 HOST_IP=host.docker.internal
 # Build settings (this will have an affect on build only)

--- a/compose/build.yml
+++ b/compose/build.yml
@@ -1,4 +1,4 @@
-version: "2"
+version: "3.7"
 services:
 
   nodejs:

--- a/compose/mariadb.yml
+++ b/compose/mariadb.yml
@@ -1,4 +1,4 @@
-version: "2"
+version: "3.7"
 services:
 
   mariadb:
@@ -13,12 +13,8 @@ services:
       - ./mariadb:/etc/mysql/conf.d
     depends_on:
       - nginx
-    mem_swappiness: 1
     networks:
       - totara
 
 volumes:
     mariadb-data:
-
-networks:
-  totara:

--- a/compose/mssql.yml
+++ b/compose/mssql.yml
@@ -1,4 +1,4 @@
-version: "2"
+version: "3.7"
 services:
 
   mssql:
@@ -19,6 +19,3 @@ services:
 
 volumes:
     mssql-data:
-
-networks:
-  totara:

--- a/compose/mysql.yml
+++ b/compose/mysql.yml
@@ -1,4 +1,4 @@
-version: "2"
+version: "3.7"
 services:
 
   mysql8:
@@ -32,6 +32,3 @@ services:
 volumes:
   mysql-data:
   mysql80-data:
-
-networks:
-  totara:

--- a/compose/nginx.yml
+++ b/compose/nginx.yml
@@ -1,4 +1,4 @@
-version: "2"
+version: "3.7"
 services:
 
   nginx:
@@ -48,6 +48,3 @@ services:
 
 volumes:
   totara-data:
-
-networks:
-  totara:

--- a/compose/pgsql.yml
+++ b/compose/pgsql.yml
@@ -1,4 +1,4 @@
-version: "2"
+version: "3.7"
 services:
 
   pgsql93:
@@ -92,6 +92,3 @@ volumes:
   pgsql10-data:
   pgsql11-data:
   pgsql12-data:
-
-networks:
-  totara:

--- a/compose/php.yml
+++ b/compose/php.yml
@@ -1,4 +1,4 @@
-version: "2"
+version: "3.7"
 services:
 
   php-5.3:

--- a/compose/selenium.yml
+++ b/compose/selenium.yml
@@ -1,4 +1,4 @@
-version: "2"
+version: "3.7"
 services:
 
   selenium-hub:
@@ -40,6 +40,3 @@ services:
       - "4445:4444"
     networks:
       - totara
-
-networks:
-  totara:

--- a/compose/sync.yml
+++ b/compose/sync.yml
@@ -1,4 +1,4 @@
-version: "2"
+version: "3.7"
 services:
 
   nginx:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "2"
+version: "3.7"
 services:
 
   # this file only contains a small part of the container definitions
@@ -42,3 +42,4 @@ volumes:
 
 networks:
   totara:
+    name: totara


### PR DESCRIPTION
This sets the docker-compose version to 3.7 and sets a name for the network. It also fixes the readme instructions on how to configure the HOST_IP for xdebug on linux.