### PR TITLE
Extend nginx timeout setting

### DIFF
--- a/nginx/config/server.conf
+++ b/nginx/config/server.conf
@@ -23,6 +23,8 @@ location ~ [^/]\.php(/|$) {
     fastcgi_param PATH_INFO       $fastcgi_path_info;
     fastcgi_buffers 16 16k;
     fastcgi_buffer_size 32k;
+    fastcgi_read_timeout 1d;
+    proxy_read_timeout 1d;
 }
 
 # serve static files directly


### PR DESCRIPTION
Changes the default from timing out after 30s to 1 day to avoid timeouts when testing performance issues.