### PR TITLE
Remove unused and problematic opcache configuration

### DIFF
--- a/php/php70/config/php.ini
+++ b/php/php70/config/php.ini
@@ -6,12 +6,6 @@ date.timezone = Pacific/Auckland
 memory_limit=256M
 ; necessary as Xdebug impacts performance that hard
 max_execution_time=120
-;opcache.revalidate_freq=0
-;opcache.validate_timestamps=0 (comment this out in your dev environment)
-;opcache.max_accelerated_files=16000
-;opcache.memory_consumption=192
-;opcache.interned_strings_buffer=16
-;opcache.fast_shutdown=1
 ; relax file upload limits
 post_max_size = 64M
 upload_max_filesize = 64M

--- a/php/php71/config/php.ini
+++ b/php/php71/config/php.ini
@@ -6,12 +6,6 @@ date.timezone = Pacific/Auckland
 memory_limit=256M
 ; necessary as Xdebug impacts performance that hard
 max_execution_time=120
-;opcache.revalidate_freq=0
-;opcache.validate_timestamps=0 (comment this out in your dev environment)
-;opcache.max_accelerated_files=16000
-;opcache.memory_consumption=192
-;opcache.interned_strings_buffer=16
-;opcache.fast_shutdown=1
 ; relax file upload limits
 post_max_size = 64M
 upload_max_filesize = 64M

--- a/php/php72/config/php.ini
+++ b/php/php72/config/php.ini
@@ -6,12 +6,6 @@ date.timezone = Pacific/Auckland
 memory_limit=256M
 ; necessary as Xdebug impacts performance that hard
 max_execution_time=120
-;opcache.revalidate_freq=0
-;opcache.validate_timestamps=0 (comment this out in your dev environment)
-;opcache.max_accelerated_files=16000
-;opcache.memory_consumption=192
-;opcache.interned_strings_buffer=16
-;opcache.fast_shutdown=1
 ; relax file upload limits
 post_max_size = 64M
 upload_max_filesize = 64M

--- a/php/php73/config/php.ini
+++ b/php/php73/config/php.ini
@@ -4,15 +4,8 @@ error_reporting = E_ALL & ~E_DEPRECATED
 max_input_vars = 2000
 date.timezone = Pacific/Auckland
 memory_limit=256M
-opcache.optimization_level=0x7FFFBBFF
 ; necessary as Xdebug impacts performance that hard
 max_execution_time=120
-;opcache.revalidate_freq=0
-;opcache.validate_timestamps=0 (comment this out in your dev environment)
-;opcache.max_accelerated_files=16000
-;opcache.memory_consumption=192
-;opcache.interned_strings_buffer=16
-;opcache.fast_shutdown=1
 ; relax file upload limits
 post_max_size = 64M
 upload_max_filesize = 64M

--- a/php/php74/config/php.ini
+++ b/php/php74/config/php.ini
@@ -4,7 +4,6 @@ error_reporting = E_ALL & ~E_DEPRECATED
 max_input_vars = 2000
 date.timezone = Pacific/Auckland
 memory_limit=256M
-opcache.optimization_level=0x7FFFBBFF
 ; necessary as Xdebug impacts performance that hard
 max_execution_time=120
 post_max_size = 64M


### PR DESCRIPTION
This fixes #82 

A while ago when PHP 7.3 was still in it's RC phase there was a bug with opcache causing a crash which could be fixed with a special php.ini opcache directive. It was still in the php.ini and in the meanwhile with the current stable 7.3 version this actually does the opposite and causes a crash.

Removed the culprit. 