### PR TITLE
Fix tnpm on Mac OS

### DIFF
--- a/bin/tnpm
+++ b/bin/tnpm
@@ -6,7 +6,7 @@ PROJECTPATH="$( cd $SCRIPTPATH && cd ..; pwd -P )"
 export $(egrep -v '^#' $PROJECTPATH/.env | xargs)
 
 # If tnpm is called from a subdirectory, then we run npm in that subdirectory too
-[[ "$PWD" =~ ^$LOCAL_SRC/(.*)$ ]]
-TOTARASITEDIR="$REMOTE_SRC/${BASH_REMATCH[1]}"
+SUBPATH="${PWD//$LOCAL_SRC/}"
+TOTARASITEDIR="$REMOTE_SRC/$SUBPATH"
 
 $SCRIPTPATH/tdocker run -w "$TOTARASITEDIR" nodejs npm "$@"


### PR DESCRIPTION
On MacOS with zsh the regex used in the tnpm script does not work as expected.

I changed to a (hopefully) more compatible solution.
