### PR TITLE
Remove totara network from linux docker host command

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -7,7 +7,7 @@ MYSQL_ROOT_PW=root
 MSSQL_SA_PW=Totara.Mssql1
 # set this to your local IP address
 # for mac just use "host.docker.internal"
-# for linux run command "docker run --rm --network=totara alpine ip -4 route list match 0/0 | cut -d' ' -f3" and use the resulting ip address
+# for linux run command "docker run --rm alpine ip -4 route list match 0/0 | cut -d' ' -f3" and use the resulting ip address
 # most probably it is 172.17.0.1
 HOST_IP=host.docker.internal
 # Build settings (this will have an affect on build only)


### PR DESCRIPTION
In order to get Xdebug working on linux hosts, we must remove the totara network from the docker host command for linux users. When the totara network is included, a different IP is resolved each time the command is run, which results in Xdebug not being able to resolve the correct host.