### PR TITLE
Fix zsh history

### DIFF
--- a/compose/php.yml
+++ b/compose/php.yml
@@ -232,7 +232,7 @@ services:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
       - $HOME/.bash_history:/root/.bash_history
-      - zsh-history:zsh_history
+      - zsh-history:/root/.zsh_history
       - ./shell:/root/custom_shell
     depends_on:
       - php-7.1-debug


### PR DESCRIPTION
Getting this with PHP 7.1:

```
totara_sync is up-to-date
totara_php71_debug is up-to-date
Creating totara_php71 ... error

ERROR: for totara_php71  Cannot create container for service php-7.1: invalid volume specification: 'docker_zsh-history:zsh_history:rw': invalid mount config for type "volume": invalid mount path: 'zsh_history' mount path must be absolute

ERROR: for php-7.1  Cannot create container for service php-7.1: invalid volume specification: 'docker_zsh-history:zsh_history:rw': invalid mount config for type "volume": invalid mount path: 'zsh_history' mount path must be absolute
ERROR: Encountered errors while bringing up the project.
```