### PR TITLE
Add automatic check for updates

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,3 +1,5 @@
+# Disable auto-updating of docker-dev by setting this to 0
+AUTO_UPDATE=1
 # set the path here to your local src path
 LOCAL_SRC=/your/totara/src/path
 # some defaults

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ mutagen.yml.lock
 /shell/*.sh
 /custom/*.yml
 /custom/*.yaml
+/tools/.update
 .idea/

--- a/bin/tdb
+++ b/bin/tdb
@@ -4,6 +4,8 @@ script_name=$(basename "$0")
 script_path="$( cd "$(dirname $0)" || exit; pwd -P )"
 project_path="$( cd "$script_path" && cd ..; pwd -P )"
 
+source "$project_path/tools/check_for_update.sh"
+
 export $(grep -E -v '^#' "$project_path/.env" | xargs)
 
 # Handle any flags that have been specified

--- a/bin/tdocker
+++ b/bin/tdocker
@@ -5,6 +5,8 @@ PROJECTPATH="$( cd $SCRIPTPATH && cd ..; pwd -P )"
 
 cd $PROJECTPATH;
 
+source "$PROJECTPATH/tools/check_for_update.sh"
+
 files=(
     "docker-compose.yml"
     "compose/apache.yml"

--- a/bin/tngrok
+++ b/bin/tngrok
@@ -3,6 +3,8 @@
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 PROJECTPATH="$( cd $SCRIPTPATH && cd ..; pwd -P )"
 
+source "$PROJECTPATH/tools/check_for_update.sh"
+
 export $(egrep -v '^#' $PROJECTPATH/.env | xargs)
 
 if [ -z $1 ]; then

--- a/bin/tpull
+++ b/bin/tpull
@@ -1,6 +1,9 @@
 #!/bin/bash
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+PROJECTPATH="$( cd $SCRIPTPATH && cd ..; pwd -P )"
+
+source "$PROJECTPATH/tools/check_for_update.sh"
 
 if [ $# -eq 0 ] || [ $1 == 'all' ]; then
     # pulling all images already present from docker hub

--- a/tools/check_for_update.sh
+++ b/tools/check_for_update.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+if [[ -z "$LOCAL_SRC" ]]; then
+    script_path=$( cd "$(dirname "$0")" || exit; pwd -P )
+    project_path=$( cd "$script_path" && cd ..; pwd -P )
+    export $(grep -E -v '^#' "$project_path/.env" | xargs)
+fi
+
+# We don't want to update it if:
+# * Automatic updating is disabled in .env
+# * The current user doesn't have write permissions nor owns the docker-dev directory
+# * The current branch is not master
+# * Git isn't available
+if [[ "$AUTO_UPDATE" == "0" ]] \
+   || [[ ! -w "$project_path" || ! -O "$project_path" ]] \
+   || ! command -v git &>/dev/null \
+   || [[ $(git rev-parse --abbrev-ref HEAD) != "master" ]]; then
+    return &> /dev/null || exit
+fi
+
+# Check when we last checked for updates.
+current_time=$(date +%s)
+
+update_time() {
+    echo "last_update_time=$current_time" > "$project_path/tools/.update"
+}
+
+if [[ ! -f "$project_path/tools/.update" ]]; then
+    # Haven't updated before, can skip for now.
+    update_time
+    return &> /dev/null || exit
+fi
+
+export $(grep -E -v '^#' "$project_path/tools/.update" | xargs)
+if [[ -z "$last_update_time" ]]; then
+    # Haven't updated before, can skip for now.
+    update_time
+    return &> /dev/null || exit
+fi
+
+seven_days_in_seconds=604800
+update_time_difference=$(expr $current_time - $last_update_time)
+if [ "$update_time_difference" -lt "$seven_days_in_seconds" ]; then
+    # Last updated less than 7 days ago, can skip for now.
+    return &> /dev/null || exit
+fi
+
+# No matter what, something will be done now, so update the last updated timestamp.
+update_time
+
+# If the current head is the same as the latest remote master then we don't need to update.
+current_version_hash=`git rev-parse HEAD`
+latest_version_hash=($( git ls-remote --heads https://github.com/totara/totara-docker-dev.git refs/heads/master))
+latest_version_hash=${latest_version_hash[0]}
+if [[ "$current_version_hash" == "$latest_version_hash" ]]; then
+    # There aren't any updates. Will check again in 7 days.
+    return &> /dev/null || exit
+fi
+
+read -p "There is a newer version of totara-docker-dev available. Would you like to update? [Y/n] " confirm
+if [[ "$confirm" == "y" || "$confirm" == "Y" ]]; then
+    source "$project_path/tools/update.sh"
+    # Containers have been stopped, so should quit out and not continue running whatever the command was.
+    exit
+fi
+
+# Now we continue on and run the command that they originally wanted to run.

--- a/tools/update.sh
+++ b/tools/update.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+script_path=$( cd "$(dirname "$0")" || exit; pwd -P )
+project_path=$( cd "$script_path" && cd ..; pwd -P )
+
+old_tag=$(git describe --tags)
+
+# Big chain of commands we only want to run if the previous one was successful
+echo -ne "Stopping all running containers" && \
+    "$project_path"/bin/tdown &> /dev/null && \
+    echo -e "...done\n\nPulling the latest code" && \
+    git pull origin master --rebase && \
+    echo -ne "\nPulling the latest container images - this could take a few minutes" && \
+    "$project_path"/bin/tpull &> /dev/null && \
+    echo -e "...done\n\n\x1B[2mSuccessfully updated to $(git describe --tags) from $old_tag\x1B[0m" && \
+    echo "View the latest changes here: https://github.com/totara/totara-docker-dev/releases/latest" && \
+    echo "Note: You will need to start your containers again with the tup command" && \
+    return &> /dev/null || exit
+
+# Something failed...
+echo -e "\n\x1B[31mThere was an error while updating.\x1B[0m"
+echo "The update can be attempted again by running the $script_path/$(basename $0) script."


### PR DESCRIPTION
If someone is on an old version of docker-dev, then they will be asked if they want to update every 2 days if there is a new version available. It will only ask if they are on the master branch, and if the local commit hash and the remote master hash don't match. This check will not happen if AUTO_UPDATE is set to '0' in the .env file.