### PR TITLE
Fix mariadb 10.5 container name not being resolved by tdb

### DIFF
--- a/bin/tdb
+++ b/bin/tdb
@@ -161,7 +161,7 @@ if [[ "$db_host" == 'pgsql' ]]; then
 elif [[ "$db_host" == 'mysql' ]]; then
     db_container_name='totara_mysql57'
 elif [[ "$db_host" == 'mariadb' ]]; then
-    db_container_name='totara_mariadb104'
+    db_container_name='totara_mariadb105'
 else
     db_container_name="totara_${db_host}"
 fi


### PR DESCRIPTION
Forgot to update ```tdb``` when doing https://github.com/totara/totara-docker-dev/pull/127