### PR TITLE
Consistently use the correct timezone across all containers

### DIFF
--- a/compose/mariadb.yml
+++ b/compose/mariadb.yml
@@ -7,6 +7,7 @@ services:
     ports:
       - "3307:3306"
     environment:
+      TZ: ${TIME_ZONE}
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PW}
     volumes:
       - mariadb-data:/var/lib/mysql
@@ -22,6 +23,7 @@ services:
     ports:
       - "3309:3306"
     environment:
+      TZ: ${TIME_ZONE}
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PW}
     volumes:
       - mariadb104-data:/var/lib/mysql
@@ -37,6 +39,7 @@ services:
     ports:
       - "3302:3306"
     environment:
+      TZ: ${TIME_ZONE}
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PW}
     volumes:
       - mariadb102-data:/var/lib/mysql

--- a/compose/mssql.yml
+++ b/compose/mssql.yml
@@ -7,6 +7,7 @@ services:
     ports:
       - "1433:1433"
     environment:
+      TZ: ${TIME_ZONE}
       ACCEPT_EULA: Y
       SA_PASSWORD: ${MSSQL_SA_PW}
       MSSQL_PID: Developer

--- a/compose/mysql.yml
+++ b/compose/mysql.yml
@@ -7,6 +7,7 @@ services:
     ports:
       - "3308:3306"
     environment:
+      TZ: ${TIME_ZONE}
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PW}
     depends_on:
       - nginx
@@ -22,6 +23,7 @@ services:
     ports:
       - "3306:3306"
     environment:
+      TZ: ${TIME_ZONE}
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PW}
     depends_on:
       - nginx

--- a/compose/nginx.yml
+++ b/compose/nginx.yml
@@ -5,6 +5,7 @@ services:
     image: totara/docker-dev-nginx
     container_name: totara_nginx
     environment:
+      - TZ=${TIME_ZONE}
       - REMOTE_DATA
     ports:
       - "80:80"

--- a/compose/pgsql.yml
+++ b/compose/pgsql.yml
@@ -7,6 +7,7 @@ services:
     ports:
       - "5493:5432"
     environment:
+      TZ: ${TIME_ZONE}
       PGDATA: /var/lib/postgresql/data/pgdata
     command:
       postgres -c 'config_file=/etc/postgresql/postgresql.conf'
@@ -24,6 +25,7 @@ services:
     ports:
       - "5496:5432"
     environment:
+      TZ: ${TIME_ZONE}
       PGDATA: /var/lib/postgresql/data/pgdata
       POSTGRES_HOST_AUTH_METHOD: trust
     command:
@@ -42,6 +44,7 @@ services:
     ports:
       - "5410:5432"
     environment:
+      TZ: ${TIME_ZONE}
       PGDATA: /var/lib/postgresql/data/pgdata
     command:
       postgres -c 'config_file=/etc/postgresql/postgresql.conf'
@@ -59,6 +62,7 @@ services:
     ports:
       - "5411:5432"
     environment:
+      TZ: ${TIME_ZONE}
       PGDATA: /var/lib/postgresql/data/pgdata
     command:
       postgres -c 'config_file=/etc/postgresql/postgresql.conf'
@@ -76,6 +80,7 @@ services:
     ports:
       - "5432:5432"
     environment:
+      TZ: ${TIME_ZONE}
       PGDATA: /var/lib/postgresql/data/pgdata
     command:
       postgres -c 'config_file=/etc/postgresql/postgresql.conf'

--- a/compose/php.yml
+++ b/compose/php.yml
@@ -7,6 +7,7 @@ services:
     working_dir: ${REMOTE_SRC}
     environment:
       CONTAINERNAME: php-5.3
+      TZ: ${TIME_ZONE}
       HIST_FILE: /root/.bash_history
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
@@ -25,6 +26,7 @@ services:
     working_dir: ${REMOTE_SRC}
     environment:
       CONTAINERNAME: php-5.3-debug
+      TZ: ${TIME_ZONE}
       HOST_IP: ${HOST_IP}
       PHP_IDE_CONFIG: serverName=totara53
       HIST_FILE: /root/.bash_history
@@ -43,6 +45,7 @@ services:
     working_dir: ${REMOTE_SRC}
     environment:
       CONTAINERNAME: php-5.4
+      TZ: ${TIME_ZONE}
       HIST_FILE: /root/.bash_history
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
@@ -61,6 +64,7 @@ services:
     working_dir: ${REMOTE_SRC}
     environment:
       CONTAINERNAME: php-5.4-debug
+      TZ: ${TIME_ZONE}
       HOST_IP: ${HOST_IP}
       PHP_IDE_CONFIG: serverName=totara54
       HIST_FILE: /root/.bash_history
@@ -76,6 +80,8 @@ services:
   php-5.4-cron:
     image: totara/docker-dev-php54-cron
     container_name: totara_php54_cron
+    environment:
+      TZ: ${TIME_ZONE}
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
@@ -89,6 +95,7 @@ services:
     working_dir: ${REMOTE_SRC}
     environment:
       CONTAINERNAME: php-5.5
+      TZ: ${TIME_ZONE}
       HIST_FILE: /root/.bash_history
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
@@ -107,6 +114,7 @@ services:
     working_dir: ${REMOTE_SRC}
     environment:
       CONTAINERNAME: php-5.5-debug
+      TZ: ${TIME_ZONE}
       XDEBUG_CONFIG: remote_host=${HOST_IP}
       PHP_IDE_CONFIG: serverName=totara55
       HIST_FILE: /root/.bash_history
@@ -122,6 +130,8 @@ services:
   php-5.5-cron:
     image: totara/docker-dev-php55-cron
     container_name: totara_php55_cron
+    environment:
+      TZ: ${TIME_ZONE}
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
@@ -135,6 +145,7 @@ services:
     working_dir: ${REMOTE_SRC}
     environment:
       CONTAINERNAME: php-5.6
+      TZ: ${TIME_ZONE}
       HIST_FILE: /root/.bash_history
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
@@ -153,6 +164,7 @@ services:
     working_dir: ${REMOTE_SRC}
     environment:
       CONTAINERNAME: php-5.6-debug
+      TZ: ${TIME_ZONE}
       XDEBUG_CONFIG: remote_host=${HOST_IP}
       PHP_IDE_CONFIG: serverName=totara56
       HIST_FILE: /root/.bash_history
@@ -168,6 +180,8 @@ services:
   php-5.6-cron:
     image: totara/docker-dev-php56-cron
     container_name: totara_php56_cron
+    environment:
+      TZ: ${TIME_ZONE}
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
@@ -181,6 +195,7 @@ services:
     working_dir: ${REMOTE_SRC}
     environment:
       CONTAINERNAME: php-7.0
+      TZ: ${TIME_ZONE}
       HIST_FILE: /root/.bash_history
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
@@ -199,6 +214,7 @@ services:
     working_dir: ${REMOTE_SRC}
     environment:
       CONTAINERNAME: php-7.0-debug
+      TZ: ${TIME_ZONE}
       XDEBUG_CONFIG: remote_host=${HOST_IP}
       PHP_IDE_CONFIG: serverName=totara70
       HIST_FILE: /root/.bash_history
@@ -214,6 +230,8 @@ services:
   php-7.0-cron:
     image: totara/docker-dev-php70-cron
     container_name: totara_php70_cron
+    environment:
+      TZ: ${TIME_ZONE}
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
@@ -227,6 +245,7 @@ services:
     working_dir: ${REMOTE_SRC}
     environment:
       CONTAINERNAME: php-7.1
+      TZ: ${TIME_ZONE}
       HIST_FILE: /root/.bash_history
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
@@ -245,6 +264,7 @@ services:
     working_dir: ${REMOTE_SRC}
     environment:
       CONTAINERNAME: php-7.1-debug
+      TZ: ${TIME_ZONE}
       XDEBUG_CONFIG: remote_host=${HOST_IP}
       PHP_IDE_CONFIG: serverName=totara71
       HIST_FILE: /root/.bash_history
@@ -260,6 +280,8 @@ services:
   php-7.1-cron:
     image: totara/docker-dev-php71-cron
     container_name: totara_php71_cron
+    environment:
+      TZ: ${TIME_ZONE}
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
@@ -273,6 +295,7 @@ services:
     working_dir: ${REMOTE_SRC}
     environment:
       CONTAINERNAME: php-7.2
+      TZ: ${TIME_ZONE}
       HIST_FILE: /root/.bash_history
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
@@ -291,6 +314,7 @@ services:
     working_dir: ${REMOTE_SRC}
     environment:
       CONTAINERNAME: php-7.2-debug
+      TZ: ${TIME_ZONE}
       XDEBUG_CONFIG: remote_host=${HOST_IP}
       PHP_IDE_CONFIG: serverName=totara72
       HIST_FILE: /root/.bash_history
@@ -306,6 +330,8 @@ services:
   php-7.2-cron:
     image: totara/docker-dev-php72-cron
     container_name: totara_php72_cron
+    environment:
+      TZ: ${TIME_ZONE}
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
@@ -319,6 +345,7 @@ services:
     working_dir: ${REMOTE_SRC}
     environment:
       CONTAINERNAME: php-7.3
+      TZ: ${TIME_ZONE}
       HIST_FILE: /root/.bash_history
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
@@ -337,6 +364,7 @@ services:
     working_dir: ${REMOTE_SRC}
     environment:
       CONTAINERNAME: php-7.3-debug
+      TZ: ${TIME_ZONE}
       XDEBUG_CONFIG: remote_host=${HOST_IP}
       PHP_IDE_CONFIG: serverName=totara73
       HIST_FILE: /root/.bash_history
@@ -352,6 +380,8 @@ services:
   php-7.3-cron:
     image: totara/docker-dev-php73-cron
     container_name: totara_php73_cron
+    environment:
+      TZ: ${TIME_ZONE}
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
@@ -365,6 +395,7 @@ services:
     working_dir: ${REMOTE_SRC}
     environment:
       CONTAINERNAME: php-7.4
+      TZ: ${TIME_ZONE}
       HIST_FILE: /root/.bash_history
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
@@ -383,6 +414,7 @@ services:
     working_dir: ${REMOTE_SRC}
     environment:
       CONTAINERNAME: php-7.4-debug
+      TZ: ${TIME_ZONE}
       XDEBUG_CONFIG: remote_host=${HOST_IP}
       PHP_IDE_CONFIG: serverName=totara74
       HIST_FILE: /root/.bash_history
@@ -398,6 +430,8 @@ services:
   php-7.4-cron:
     image: totara/docker-dev-php74-cron
     container_name: totara_php74_cron
+    environment:
+      TZ: ${TIME_ZONE}
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}

--- a/compose/selenium.yml
+++ b/compose/selenium.yml
@@ -9,6 +9,7 @@ services:
     networks:
       - totara
     environment:
+      - TZ=${TIME_ZONE}
       - GRID_MAX_SESSION=8
       - GRID_TIMEOUT=7200
       - GRID_CLEAN_UP_CYCLE=120000
@@ -18,6 +19,7 @@ services:
   selenium-chrome:
     image: selenium/node-chrome:3.141.59-oxygen
     environment:
+      - TZ=${TIME_ZONE}
       - HUB_PORT_4444_TCP_ADDR=selenium-hub
       - HUB_PORT_4444_TCP_PORT=4444
       - NODE_MAX_INSTANCES=8
@@ -30,6 +32,8 @@ services:
     container_name: totara_chrome_standalone_debug
     ports:
       - "5901:5900"
+    environment:
+      - TZ=${TIME_ZONE}
     networks:
       - totara
 
@@ -38,5 +42,7 @@ services:
     container_name: totara_chrome_standalone
     ports:
       - "4445:4444"
+    environment:
+      - TZ=${TIME_ZONE}
     networks:
       - totara

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
   nodejs:
     image: node:12
     container_name: totara_nodejs
+    environment:
+      TZ: ${TIME_ZONE}
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
@@ -20,6 +22,8 @@ services:
     container_name: totara_mailcatcher
     ports:
       - "8080:80"
+    environment:
+      TZ: ${TIME_ZONE}
     networks:
       - totara
 
@@ -27,6 +31,8 @@ services:
     image: redis
     # activate persistency
     command: "redis-server --appendonly yes"
+    environment:
+      TZ: ${TIME_ZONE}
     volumes:
       - redis-data:/data
     networks:
@@ -34,6 +40,8 @@ services:
 
   memcached:
     image: memcached
+    environment:
+      TZ: ${TIME_ZONE}
     networks:
       - totara
 


### PR DESCRIPTION
To test this, you can run ```tdocker run CONTAINERNAME /bin/sh -c 'date'``` with a few containers, and make sure it matches the timezone set in your .env