### PR TITLE
Add support for T15+ in tdb

### DIFF
--- a/bin/tdb
+++ b/bin/tdb
@@ -80,18 +80,14 @@ php_get_version_code="
     }
 "
 totara_version=$(php -r "$php_get_version_code")
-if [[ "$totara_version" =~ '14.' || "$totara_version" =~ '14dev' ]]; then
-    php_version='7.3'
-elif [[ "$totara_version" =~ '13.' || "$totara_version" =~ '13dev' ]]; then
-    php_version='7.3'
-elif [[ "$totara_version" =~ '12.' || "$totara_version" =~ '11.' ]]; then
-    php_version='7.3'
-elif [[ "$totara_version" =~ '10.' ]]; then
-    php_version='7.2'
+if [[ "$totara_version" =~ '^2.' ]]; then
+    php_version='5.6'
 elif [[ "$totara_version" =~ '9.' ]]; then
     php_version='7.0'
+elif [[ "$totara_version" =~ '10.' ]]; then
+    php_version='7.2'
 else
-    php_version='5.6'
+    php_version='7.3'
 fi
 php_container_version=$(echo $php_version | sed 's/[^0-9]*//g')
 

--- a/bin/tdb
+++ b/bin/tdb
@@ -291,6 +291,15 @@ if [ "$db_type" == 'pgsql' ]; then
         exit
     fi
 
+
+# MySQL and MariaDB need special character sets and collation
+character_set='utf8mb4'
+collation='utf8mb4_bin'
+if [[ $db_host == 'mysql8' ]]; then
+    collation='utf8mb4_0900_as_cs'
+fi
+
+
 ##########################################
 #                 MySQL                  #
 ##########################################
@@ -300,13 +309,6 @@ elif [ "$db_type" == 'mysqli' ]; then
         # Export password to avoid insecure password warnings
         eval "$db_command sh -c 'export MYSQL_PWD=$db_password; mysql -u\"$db_user\" -e \"$1\"'"
     }
-
-    character_set='utf8'
-    collation='utf8_bin'
-    if [[ $db_host == 'mysql8' ]]; then
-        character_set='utf8mb4'
-        collation='utf8mb4_0900_as_cs'
-    fi
 
     # Create mysql database
     if [ "$action" == 'create' ]; then
@@ -358,12 +360,12 @@ elif [ "$db_type" == 'mariadb' ]; then
 
     # Create mariadb database
     if [ "$action" == 'create' ]; then
-        eval "$db_sql_cmd -e \"CREATE DATABASE $db_name DEFAULT CHARACTER SET utf8 COLLATE utf8_bin\"" || exit
+        eval "$db_sql_cmd -e \"CREATE DATABASE $db_name DEFAULT CHARACTER SET $character_set COLLATE $collation\"" || exit
 
     # Drop and create mariadb database
     elif [ "$action" == 'recreate' ]; then
         eval "$db_sql_cmd -e \"DROP DATABASE IF EXISTS $db_name\"" >> /dev/null
-        eval "$db_sql_cmd -e \"CREATE DATABASE $db_name DEFAULT CHARACTER SET utf8 COLLATE utf8_bin\"" || exit
+        eval "$db_sql_cmd -e \"CREATE DATABASE $db_name DEFAULT CHARACTER SET $character_set COLLATE $collation\"" || exit
 
     # Drop mariadb database
     elif [ "$action" == 'drop' ]; then
@@ -376,7 +378,7 @@ elif [ "$db_type" == 'mariadb' ]; then
     # Restore mariadb database
     elif [ "$action" == 'restore' ]; then
         eval "$db_sql_cmd -e \"DROP DATABASE IF EXISTS $db_name\""
-        eval "$db_sql_cmd -e \"CREATE DATABASE $db_name DEFAULT CHARACTER SET utf8 COLLATE utf8_bin\""
+        eval "$db_sql_cmd -e \"CREATE DATABASE $db_name DEFAULT CHARACTER SET $character_set COLLATE $collation\""
         docker cp "$backup_file_local" "$db_container":"$backup_file_remote"
         $db_command sh -c "mysql -u\"$db_user\" -p\"$db_password\" $db_name < $backup_file_remote" >> /dev/null
         if [ "${PIPESTATUS[0]}" == '1' ]; then


### PR DESCRIPTION
The tdb command doesn't work for backing up and restoring databases for 15+ because of a bad if/else logic.
Have made it so it won't be necessary to add a new entry for new totara versions in the future.