### PR TITLE
Add Apache HTTPD 2.4 container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
 
 env:
 - DOCKER_IMAGE=nginx
+- DOCKER_IMAGE=apache
 - DOCKER_IMAGE=mssql
 - DOCKER_IMAGE=php/php53
 - DOCKER_IMAGE=php/php53-debug

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ TravisCI build: [![Build Status](https://travis-ci.com/totara/totara-docker-dev.
 Name | Version | Dockerfile | Build
 --- | --- | --- | ---
 nginx | 1.13.x | [Dockerfile](https://github.com/totara/totara-docker-dev/blob/master/nginx/Dockerfile) | [![Build status Nginx](https://img.shields.io/docker/build/totara/docker-dev-nginx.svg)](https://hub.docker.com/r/totara/docker-dev-nginx/)
+apache | 2.4.x | [Dockerfile](https://github.com/totara/totara-docker-dev/blob/master/apache/Dockerfile) | [![Build status Apache](https://img.shields.io/docker/build/totara/docker-dev-apache.svg)](https://hub.docker.com/r/totara/docker-dev-apache/)
 mssql | 2017 | [Dockerfile](https://github.com/totara/totara-docker-dev/blob/master/mssql/Dockerfile) | [![Build status Mssql](https://img.shields.io/docker/build/totara/docker-dev-mssql.svg)](https://hub.docker.com/r/totara/docker-dev-mssql/)
 php53 | 5.3 |  [Dockerfile](https://github.com/totara/totara-docker-dev/blob/master/php/php53/Dockerfile) | [![Build status PHP 5.3](https://img.shields.io/docker/build/totara/docker-dev-php53.svg)](https://hub.docker.com/r/totara/docker-dev-php53/)
 php53-debug | 5.3 + xdebug 2.0.5 |  [Dockerfile](https://github.com/totara/totara-docker-dev/blob/master/php/php53-debug/Dockerfile) | [![Build status PHP 5.3 Debug](https://img.shields.io/docker/build/totara/docker-dev-php53-debug.svg)](https://hub.docker.com/r/totara/docker-dev-php53-debug/)
@@ -36,6 +37,7 @@ Although this project started as a development environment for Totara Learn it c
 
 ### What you get:
  * [NGINX](https://nginx.org/) as a webserver
+ * [Apache](https://httpd.apache.org/) as an alternative webserver
  * [PHP](http://php.net/) 5.3, 5.4, 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1 to test for different versions
  * [PostgreSQL](https://www.postgresql.org/) (9.3, 9.6, 10, 11, 12), [MariaDB](https://mariadb.org/) (10.2, 10.4 and 10.5) and [MySQL](https://www.mysql.com/) (5.7.x and 8), and [Microsoft SQL Server 2017](https://www.microsoft.com/en-us/sql-server/sql-server-2017) support
  * A [PHPUnit](https://phpunit.de/) and [Behat](http://behat.org/en/latest/) setup to run tests (including [Selenium](https://www.seleniumhq.org/))

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -1,0 +1,16 @@
+FROM httpd:2.4
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    nano \
+    openssl \
+    gettext
+
+COPY config/httpd.conf /usr/local/apache2/conf/httpd.conf
+COPY config/server.conf /usr/local/apache2/conf.d/server.conf
+COPY config/local-server.conf /usr/local/apache2/conf.d/local-server.conf
+COPY config/remote-server.conf /usr/local/apache2/conf.d/remote-server.conf
+COPY entrypoint.sh /entrypoint.sh
+
+RUN chmod +x /entrypoint.sh
+
+CMD /entrypoint.sh

--- a/apache/config/httpd.conf
+++ b/apache/config/httpd.conf
@@ -1,0 +1,76 @@
+# The main httpd definition file
+ServerRoot "/usr/local/apache2"
+
+Listen 80
+Listen 443
+Listen 8443
+
+# Add the required modules here
+LoadModule alias_module modules/mod_alias.so
+LoadModule authz_core_module modules/mod_authz_core.so
+LoadModule deflate_module modules/mod_deflate.so
+LoadModule dir_module modules/mod_dir.so
+LoadModule filter_module modules/mod_filter.so
+LoadModule log_config_module modules/mod_log_config.so
+LoadModule logio_module modules/mod_logio.so
+LoadModule mime_magic_module modules/mod_mime_magic.so
+LoadModule mime_module modules/mod_mime.so
+LoadModule mpm_event_module modules/mod_mpm_event.so
+LoadModule proxy_module modules/mod_proxy.so
+LoadModule proxy_fcgi_module modules/mod_proxy_fcgi.so
+LoadModule rewrite_module modules/mod_rewrite.so
+LoadModule socache_shmcb_module modules/mod_socache_shmcb.so
+LoadModule ssl_module modules/mod_ssl.so
+LoadModule unixd_module modules/mod_unixd.so
+LoadModule vhost_alias_module modules/mod_vhost_alias.so
+
+User daemon
+Group daemon
+
+<Directory "/">
+    AllowOverride none
+    Require all denied
+</Directory>
+
+LogLevel info ssl:error
+LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+LogFormat "%h %l %u %t \"%r\" %>s %b" common
+LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" %I %O" combinedio
+CustomLog /dev/stdout combined
+ErrorLog /dev/stderr
+
+TypesConfig conf/mime.types
+AddType application/x-compress .Z
+AddType application/x-gzip .gz .tgz
+MIMEMagicFile conf/magic
+
+# Don't send server information header
+ServerSignature Off
+ServerTokens Prod
+
+EnableSendfile on
+
+# Supresses warning, isn't actually used as it is overrided by the vhosts
+ServerName totara
+
+SSLCertificateFile conf/server.crt
+SSLCertificateKeyFile conf/server.key
+
+UseCanonicalName Off
+
+<VirtualHost *:80>
+    Include conf.d/server.conf
+    Include conf.d/local-server.conf
+</VirtualHost>
+
+<VirtualHost *:443>
+    SSLEngine on
+    Include conf.d/server.conf
+    Include conf.d/local-server.conf
+</VirtualHost>
+
+<VirtualHost *:8443>
+    SSLEngine on
+    Include conf.d/server.conf
+    Include conf.d/remote-server.conf
+</VirtualHost>

--- a/apache/config/local-server.conf
+++ b/apache/config/local-server.conf
@@ -1,0 +1,5 @@
+# Here you can define how you want nginx to handle requests made from your local network.
+# You can do whatever you want here.
+
+# Unlimited upload size
+LimitRequestBody 0

--- a/apache/config/remote-server.conf
+++ b/apache/config/remote-server.conf
@@ -1,0 +1,10 @@
+# Here you can define how you want apache to handle requests made remotely via ngrok.
+# Take caution as potentially anyone on the internet could be able to access your machine if they have your ngrok URL.
+
+# Limit uploads to 10MB
+LimitRequestBody 10485760
+
+# Don't allow the following files/directories to be accessed
+RewriteRule (cli|tests|db|lang|classes|amd\/src|rb_sources|yui\/src) - [R=404]
+RewriteRule \.(txt|md|json|xml|mustache) - [R=404]
+RewriteRule \/\. - [R=404]

--- a/apache/config/server.conf
+++ b/apache/config/server.conf
@@ -1,0 +1,54 @@
+# Here are the server options that apply to all totara servers, regardless of whether
+# they are being accessed locally, or being accessed remotely (via ngrok)
+
+ServerAlias "totara*"
+ServerAlias "*.totara*"
+ServerAlias "totara*.behat"
+ServerAlias "*.totara*.behat"
+ServerAlias "totara*.debug"
+ServerAlias "*.totara*.debug"
+
+RewriteEngine on
+
+DocumentRoot "$REMOTE_SRC"
+
+# Direct php requests to the php-X.X container
+RewriteCond %{HTTP_HOST} totara(\d)(\d)(|\.behat)(:[0-9]+)?$
+RewriteRule \.php - [H=proxy:fcgi://php-%1.%2:9000]
+
+# Direct xdebug requests to the php-X.X-debug container
+RewriteCond %{HTTP_HOST} totara(\d)(\d)\.debug(:[0-9]+)?$
+RewriteRule \.php - [H=proxy:fcgi://php-%1.%2-debug:9000]
+
+# Handle if the site name is specified in the host, e.g. sitename.totara73
+RewriteCond %{HTTP_HOST} ^(\w+)\.totara
+RewriteRule ^(.*)$ - [E=SITENAME:%1]
+
+# If the server directory exists, then rewrite it to use it
+RewriteCond %{DOCUMENT_ROOT}/%{ENV:SITENAME}/server/version.php -f
+RewriteRule ^(.*)$ %{DOCUMENT_ROOT}/%{ENV:SITENAME}/server$1 [QSA]
+
+# Otherwise don't use the server directory
+RewriteCond %{DOCUMENT_ROOT}/%{ENV:SITENAME}/server/version.php !-f
+RewriteRule ^(.*)$ %{DOCUMENT_ROOT}/%{ENV:SITENAME}$1 [QSA]
+
+# Allow accessing files in the src directory
+<Directory $REMOTE_SRC>
+    AllowOverride All
+    Require all granted
+</Directory>
+
+DirectoryIndex index.php index.html
+
+AddDefaultCharset UTF-8
+
+# Enable gzip compression for these file types
+AddOutputFilterByType DEFLATE text/plain
+AddOutputFilterByType DEFLATE text/css
+AddOutputFilterByType DEFLATE application/json
+AddOutputFilterByType DEFLATE application/x-javascript
+AddOutputFilterByType DEFLATE text/xml
+AddOutputFilterByType DEFLATE application/xml
+AddOutputFilterByType DEFLATE application/xml+rss
+AddOutputFilterByType DEFLATE text/javascript
+AddOutputFilterByType DEFLATE image/svg+xml

--- a/apache/entrypoint.sh
+++ b/apache/entrypoint.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+echo "Using data folder: $REMOTE_DATA"
+
+cd $REMOTE_DATA || return;
+
+echo "Creating data folders..."
+
+versions=("22" "24" "25" "26" "27" "29" "9" "10" "11" "12" "13" "14" "15")
+
+for i in "${versions[@]}"
+do
+   :
+   echo "Creating folders for version $i"
+   mkdir -p "ver$i.mssql" "ver$i.mysql" "ver$i.pgsql"
+   chown -R www-data:www-data ver$i.mssql ver$i.mysql ver$i.pgsql
+   chmod g+s "ver$i.mssql" "ver$i.mysql" "ver$i.pgsql"
+
+   mkdir -p "ver$i.mssql.phpunit" "ver$i.mysql.phpunit" "ver$i.pgsql.phpunit" "ver$i.pgsql.behat"
+   chown -R www-data:www-data ver$i.pgsql.behat
+   chmod g+s "ver$i.pgsql.behat"
+done
+
+echo "done"
+
+# if there's no ssl certificate yet create it
+if [ ! -f "/usr/local/apache2/conf/server.crt" ]; then
+    openssl req \
+        -new \
+        -newkey rsa:4096 \
+        -days 3650 \
+        -nodes \
+        -x509 \
+        -subj "/C=US/ST=CA/L=SF/O=Docker-demo/CN=totara" \
+        -keyout /usr/local/apache2/conf/server.key \
+        -out /usr/local/apache2/conf/server.crt
+fi
+
+# Replace the remote src variable in the nginx configuration with
+# the one defined in the environment variables
+cp /usr/local/apache2/conf.d/server.conf /tmp/temp.conf
+envsubst '$REMOTE_SRC' < /tmp/temp.conf > /usr/local/apache2/conf.d/server.conf
+rm /tmp/temp.conf
+
+httpd -D "FOREGROUND" -k start

--- a/bin/tdocker
+++ b/bin/tdocker
@@ -7,6 +7,7 @@ cd $PROJECTPATH;
 
 files=(
     "docker-compose.yml"
+    "compose/apache.yml"
     "compose/mariadb.yml"
     "compose/mssql.yml"
     "compose/mysql.yml"

--- a/compose/apache.yml
+++ b/compose/apache.yml
@@ -1,0 +1,63 @@
+version: "3.7"
+services:
+
+  apache:
+    image: totara/docker-dev-apache
+    container_name: totara_apache
+    environment:
+      - TZ=${TIME_ZONE}
+      - REMOTE_DATA
+      - REMOTE_SRC
+    ports:
+      - "80:80"
+      - "443:443"
+      - "8443:8443" # ngrok only
+    volumes:
+      - ${LOCAL_SRC}:${REMOTE_SRC}
+      - totara-data:${REMOTE_DATA}
+    depends_on:
+      - mailcatcher
+    networks:
+      totara:
+        aliases:
+          - totara54
+          - totara54.debug
+          - totara54.behat
+          - totara54.behat.totaralms.com
+          - totara55
+          - totara55.debug
+          - totara55.behat
+          - totara55.behat.totaralms.com
+          - totara56
+          - totara56.debug
+          - totara56.behat
+          - totara56.behat.totaralms.com
+          - totara70
+          - totara70.debug
+          - totara70.behat
+          - totara70.behat.totaralms.com
+          - totara71
+          - totara71.debug
+          - totara71.behat
+          - totara71.behat.totaralms.com
+          - totara72
+          - totara72.debug
+          - totara72.behat
+          - totara72.behat.totaralms.com
+          - totara73
+          - totara73.debug
+          - totara73.behat
+          - totara73.behat.totaralms.com
+          - totara74
+          - totara74.debug
+          - totara74.behat
+          - totara74.behat.totaralms.com
+          - totara80
+          - totara80.behat
+          - totara80.behat.totaralms.com
+          - totara81
+          - totara81.behat
+          - totara81.behat.totaralms.com
+
+volumes:
+  totara-data:

--- a/compose/build.yml
+++ b/compose/build.yml
@@ -1,6 +1,9 @@
 version: "3.7"
 services:
 
+  apache:
+    build: ./apache
+
   nginx:
     build: ./nginx
 

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -4,7 +4,8 @@ ENV REMOTE_DATA=${REMOTE_DATA}
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     nano \
-    openssl
+    openssl \
+    gettext
 
 COPY config/default.conf /etc/nginx/conf.d/default.conf
 COPY config/server.conf /etc/nginx/totara-server.conf


### PR DESCRIPTION
This will help us when testing our sites. It supports the multi-site setup, ngrok, handles the server directory, and supports xdebug and behat. So this is functionally the same as the nginx container, although it is a little bit slower than nginx when loading pages.