### PR TITLE
Add better compatibility between tdb database backups and totara box databases

### DIFF
--- a/bin/tdb
+++ b/bin/tdb
@@ -6,11 +6,23 @@ project_path="$( cd "$script_path" && cd ..; pwd -P )"
 
 export $(grep -E -v '^#' "$project_path/.env" | xargs)
 
+# Handle any flags that have been specified
+flags=(
+  "-i"
+  "--ignore-dataroot"
+  "-b"
+  "--totara-box"
+)
 ignore_dataroot=0
-if [[ "$1" == "-i" || "$1" == "--ignore-dataroot" ]]; then
+for_totara_box=0
+while [[ " ${flags[@]} " =~ " $1 " ]]; do
+  if [[ "$1" == "-i" || "$1" == "--ignore-dataroot" ]]; then
     ignore_dataroot=1
-    shift
-fi
+  elif [[ "$1" == "-b" || "$1" == "--totara-box" ]]; then
+    for_totara_box=1
+  fi
+  shift
+done
 
 # Print help info
 action=$1
@@ -39,6 +51,7 @@ Actions:
 
 Options:
   -i, --ignore-dataroot    Ignore the dataroot directory when backing up and restoring.
+  -b, --totara-box         Backup and restore the database in a format compatible with Totara box (Postgres only)
 
 Examples:
   $script_name create                                // Will create a database with the name defined in your config.php if it doesn't already exist
@@ -269,14 +282,22 @@ if [ "$db_type" == 'pgsql' ]; then
 
     # Backup pgsql database
     elif [ "$action" == 'backup' ]; then
-        $db_command pg_dump -U "$db_user" "$db_name" > "$backup_file_local"
+        if [ "$for_totara_box" == "1" ]; then
+            $db_command pg_dump -U "$db_user" "$db_name" -Fc > "$backup_file_local"
+        else
+            $db_command pg_dump -U "$db_user" "$db_name" > "$backup_file_local"
+        fi
 
     # Restore pgsql database
     elif [ "$action" == 'restore' ]; then
         docker cp "$backup_file_local" "$db_container":"$backup_file_remote"
         $db_command dropdb -U "$db_user" --if-exists "$db_name"
         $db_command createdb -U "$db_user" -T template1 -E UTF-8 "$db_name"
-        $db_command psql -U "$db_user" --dbname "$db_name" -f "$backup_file_remote" >> /dev/null
+        if [ "$for_totara_box" == "1" ]; then
+            $db_command pg_restore -d "$db_name" -U "$db_user" "$backup_file_remote" >> /dev/null
+        else
+            $db_command psql -U "$db_user" --dbname "$db_name" -f "$backup_file_remote" >> /dev/null
+        fi
         if [[ "${PIPESTATUS[0]}" == '1' || ! $? -eq 0 ]]; then
             $db_command sh -c "rm $backup_file_remote"
             echo -e "\x1B[31mThere was an error while restoring $db_host database '$db_name' from file '$backup_file_local'\x1B[0m"

--- a/bin/tdb
+++ b/bin/tdb
@@ -10,14 +10,19 @@ export $(grep -E -v '^#' "$project_path/.env" | xargs)
 flags=(
   "-i"
   "--ignore-dataroot"
+  "-f"
+  "--force"
   "-b"
   "--totara-box"
 )
 ignore_dataroot=0
+force_backup=0
 for_totara_box=0
 while [[ " ${flags[@]} " =~ " $1 " ]]; do
   if [[ "$1" == "-i" || "$1" == "--ignore-dataroot" ]]; then
     ignore_dataroot=1
+  elif [[ "$1" == "-f" || "$1" == "--force" ]]; then
+    force_backup=1
   elif [[ "$1" == "-b" || "$1" == "--totara-box" ]]; then
     for_totara_box=1
   fi
@@ -51,6 +56,7 @@ Actions:
 
 Options:
   -i, --ignore-dataroot    Ignore the dataroot directory when backing up and restoring.
+  -f, --force              Overwrite any existing database and dataroot backups if they already exist.
   -b, --totara-box         Backup and restore the database in a format compatible with Totara box (Postgres only)
 
 Examples:
@@ -224,8 +230,8 @@ if [[ $action == 'backup' || $action == 'restore' ]]; then
         exit
     fi
     # If backing up, make sure we don't accidentally overwrite an existing backup file.
-    if [[ $action == 'backup' && -f "$backup_file_local" ]]; then
-        echo -e "\x1B[33mBackup file \x1B[0m\x1B[4m\x1B[37m$backup_file_local\x1B[0m\x1B[33m already exists. Delete it, then run this again.\x1B[0m"
+    if [[ $action == 'backup' && -f "$backup_file_local" && "$force_backup" == "0" ]]; then
+        echo -e "\x1B[33mBackup file \x1B[0m\x1B[4m\x1B[37m$backup_file_local\x1B[0m\x1B[33m already exists.\nIf you want to overwrite it, then run this command again with the -f option specified.\x1B[0m"
         exit
     # If restoring, make sure the backup file exists.
     elif [[ $action == 'restore' && ! -f "$backup_file_local" ]]; then
@@ -246,8 +252,8 @@ if [[ $action == 'backup' || $action == 'restore' ]]; then
         backup_dataroot_local="$backup_file_local$backup_dataroot_suffix"
 
         # If backing up, make sure we don't accidentally overwrite an existing dataroot zip.
-        if [[ $action == 'backup' && -f "$backup_dataroot_local" ]]; then
-            echo -e "\x1B[33mBackup dataroot zip already exists. Delete it, then run this again.\x1B[0m"
+        if [[ $action == 'backup' && -f "$backup_dataroot_local" && "$force_backup" == "0" ]]; then
+            echo -e "\x1B[33mBackup dataroot zip already exists.\nIf you want to overwrite it, then run this command again with the -f option specified.\x1B[0m"
             exit
         # If restoring, make sure the backup dataroot zip exists.
         elif [[ $action == 'restore' && ! -f "$backup_dataroot_local" ]]; then


### PR DESCRIPTION
This adds a new argument for the `tdb` command: `--totara-box`, which when specified, means that `tdb` will attempt to backup/restore in the same format as totara box does. This means that you can easily backup to and restore from a totara box site.