### PR TITLE
Fix broken mssql dependencies

### DIFF
--- a/php/php73/Dockerfile
+++ b/php/php73/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3-fpm
+FROM php:7.3-fpm-buster
 
 ARG TIME_ZONE=Pacific/Auckland
 
@@ -74,7 +74,7 @@ ENV LC_ALL en_US.UTF-8
 
 # install mssql extension
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
-    && curl https://packages.microsoft.com/config/debian/8/prod.list | tee /etc/apt/sources.list.d/mssql-tools.list \
+    && curl https://packages.microsoft.com/config/debian/10/prod.list > /etc/apt/sources.list.d/mssql-release.list \
     && apt-get update && ACCEPT_EULA=Y apt-get install -y \
         msodbcsql17 \
         mssql-tools \
@@ -90,8 +90,8 @@ RUN echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bash_profile \
     && echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc
 
 RUN pear config-set php_ini `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"` system \
-    && pecl install sqlsrv-5.6.0 \
-    && pecl install pdo_sqlsrv-5.6.0
+    && pecl install sqlsrv \
+    && pecl install pdo_sqlsrv
 
 RUN docker-php-ext-enable sqlsrv.so && docker-php-ext-enable pdo_sqlsrv.so
 

--- a/php/php74/Dockerfile
+++ b/php/php74/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4-fpm
+FROM php:7.4-fpm-buster
 
 ARG TIME_ZONE=Pacific/Auckland
 
@@ -65,7 +65,7 @@ ENV LC_ALL en_US.UTF-8
 
 # install mssql extension
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
-    && curl https://packages.microsoft.com/config/debian/8/prod.list | tee /etc/apt/sources.list.d/mssql-tools.list \
+    && curl https://packages.microsoft.com/config/debian/10/prod.list > /etc/apt/sources.list.d/mssql-release.list \
     && apt-get update && ACCEPT_EULA=Y apt-get install -y \
     msodbcsql17 \
     mssql-tools \
@@ -80,13 +80,20 @@ RUN echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bash_profile \
     && echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc
 
 RUN pear config-set php_ini `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"` system \
-    && pecl install sqlsrv-5.7.0preview \
-    && pecl install pdo_sqlsrv-5.7.0preview
+    && pecl install sqlsrv \
+    && pecl install pdo_sqlsrv
 
 RUN docker-php-ext-enable sqlsrv.so && docker-php-ext-enable pdo_sqlsrv.so
 
 RUN ln -fs /usr/share/zoneinfo/${TIME_ZONE} /etc/localtime \
     && dpkg-reconfigure --frontend noninteractive tzdata
+
+# Python 3.7 for ML Recommender.
+RUN apt install -y python3.7 \
+    python3-pip \
+    python3-wheel \
+    python3-venv \
+    python3-dev
 
 COPY config/php.ini /usr/local/etc/php/
 COPY config/fpm.conf /usr/local/etc/php-fpm.d/zz-totara.conf
@@ -104,10 +111,3 @@ RUN git clone https://github.com/zsh-users/zsh-syntax-highlighting ~/.oh-my-zsh/
 RUN echo 'setopt +o nomatch' > ~/.zshrc
 RUN echo 'source ~/custom_shell/.zshrc' >> ~/.zshrc
 RUN cat ~/.bashrc >> ~/.zshrc
-
-# Python 3.7 for ML Recommender.
-RUN apt install -y python3.7 \
-    python3-pip \
-    python3-wheel \
-    python3-venv \
-    python3-dev

--- a/php/php80/Dockerfile
+++ b/php/php80/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.0-fpm
+FROM php:8.0-fpm-buster
 
 ARG TIME_ZONE=Pacific/Auckland
 
@@ -56,13 +56,13 @@ ENV LC_ALL en_US.UTF-8
 
 # install mssql extension
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
-    && curl https://packages.microsoft.com/config/debian/8/prod.list | tee /etc/apt/sources.list.d/mssql-tools.list \
+    && curl https://packages.microsoft.com/config/debian/10/prod.list > /etc/apt/sources.list.d/mssql-release.list \
     && apt-get update && ACCEPT_EULA=Y apt-get install -y \
     msodbcsql17 \
     mssql-tools \
     unixodbc-dev
 
-# Workaround to get MSSQL connection working on Debian 9 (stretch)
+# Workaround to get MSSQL connection working on Debian 10 (buster)
 # https://emacstragic.net/2017/11/06/mssql-odbc-client-on-debian-9-stretch/
 RUN wget "http://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u12_amd64.deb" \
     && DEBIAN_FRONTEND=noninteractive dpkg -i ./libssl1.0.0_1.0.1t-1+deb8u12_amd64.deb
@@ -71,8 +71,8 @@ RUN echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bash_profile \
     && echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc
 
 RUN pear config-set php_ini `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"` system \
-    && pecl install sqlsrv-5.9.0beta2 \
-    && pecl install pdo_sqlsrv-5.9.0beta2
+    && pecl install sqlsrv \
+    && pecl install pdo_sqlsrv
 
 RUN docker-php-ext-enable sqlsrv.so && docker-php-ext-enable pdo_sqlsrv.so
 


### PR DESCRIPTION
The build for the images fails at the moment due to broken dependencies. It looks like the PHP docker base images switch to Debian bullseye recently and Microsoft does not offer a Mssql package for this version of Debian yet.

I forced the images to use the previous buster images and updates the links to the Microsoft package repository.