### PR TITLE
Make set_hosts script compatible with Windows

### DIFF
--- a/tools/set_hosts.sh
+++ b/tools/set_hosts.sh
@@ -4,42 +4,61 @@ script_path=$( cd "$(dirname $0)" || exit; pwd -P )
 project_path=$( cd "$script_path" && cd ..; pwd -P )
 export $(grep -E -v '^#' "$project_path/.env" | xargs)
 
+# If this is being run inside WSL, then we need to modify the /etc/hosts file on Windows
+if [[ -f "/mnt/c/Windows/System32/drivers/etc/hosts" ]]; then
+  hosts_file="/mnt/c/Windows/System32/drivers/etc/hosts"
+else
+  hosts_file="/etc/hosts"
+fi
+
+if ! sudo touch "$hosts_file" &> /dev/null; then
+  echo -e "\x1B[33m$hosts_file is not writable!\x1B[0m"
+  exit
+fi
+
+# Create a backup of the existing hosts file in case something goes wrong
+date=$(date --iso-8601)
+backup_path="$hosts_file.pre-$date.backup"
+if ! sudo test -r "$backup_path" -a -w "$backup_path"; then
+  backup_path="$HOME/hosts.pre-$date.backup"
+fi
+sudo rm -f "$backup_path"
+sudo cp "$hosts_file" "$backup_path"
+echo -e "\x1B[2mBacked up \x1B[4m$hosts_file\x1B[0m\x1B[2m to \x1B[4m$backup_path\x1B[0m"
+
+# Remove existing docker-dev hosts entries
+sudo sh -c "sed '/totara-docker-dev/d' $hosts_file > /tmp/hosts"
+sudo sh -c "sed -r '/totara[0-9]{2}/d' /tmp/hosts > $hosts_file"
+sudo rm "/tmp/hosts"
+
+# Shouldn't need to change this
+host_ip="127.0.0.1"
+
 # Get all the possible php hosts from the docker compose yml file
 php_versions=($(cat "$project_path/compose/php.yml" | sed -r -n 's/.*\php-([0-9]).([0-9])[^:]*:/\1\2/p' | uniq | sort))
 
 # Get the sub sites that we should also add host entries for
-sites=()
-if [[ ! -f "$LOCAL_SRC/config.php" && ! -f "$LOCAL_SRC/version.php" ]]; then
-    # We only want to get the visible directories located in the site directory
-    sites=($(find "$LOCAL_SRC" -maxdepth 1 -not -path '*/.*' -type d -exec basename {} \;))
-fi
+sites=($(find "$LOCAL_SRC" -mindepth 2 -maxdepth 2 -name "version.php" -type f -exec dirname {} \; | sort | xargs -n 1 basename))
 
-host_ip="127.0.0.1"
-
-hosts="$host_ip"
+hosts=""
 
 for php_version in "${php_versions[@]}"; do
-    hosts+=" totara${php_version} totara${php_version}.behat totara${php_version}.debug"
+  hosts+="\n${host_ip} totara${php_version} totara${php_version}.behat totara${php_version}.debug"
 done
 
+# Sub site hosts
 for site in "${sites[@]}"; do
-    hosts+="\n${host_ip}"
-    for php_version in "${php_versions[@]}"; do
-        hosts+=" ${site}.totara${php_version} ${site}.totara${php_version}.behat ${site}.totara${php_version}.debug"
-    done
+  for php_version in "${php_versions[@]}"; do
+    hosts+="\n${host_ip} ${site}.totara${php_version} ${site}.totara${php_version}.behat ${site}.totara${php_version}.debug"
+  done
 done
 
-# Remove existing hosts, and creates a backup of the hosts file in case something goes wrong
-sudo sed -i.bak '/totara-docker-dev/d' /etc/hosts \
-    && sudo rm /etc/hosts.bak \
-    && sudo sed -i.bak -r '/totara[0-9]{2}/d' /etc/hosts \
-    && sudo rm /etc/hosts.bak
+hosts="\n# totara-docker-dev start$hosts\n# totara-docker-dev end\n"
 
 # Add the hosts
-hosts="# totara-docker-dev start\n$hosts\n# totara-docker-dev end"
-sudo -- sh -c -e "echo '$hosts' >> /etc/hosts";
+sudo -- sh -c -e "echo '$hosts' >> $hosts_file"
 
-echo "Your /etc/hosts file has been updated";
+echo -e "Successfully updated \x1B[4m$hosts_file\x1B[0m with docker-dev hosts"
 if [ -n "$sites" ]; then
-    echo "Hosts have been added for the following sites: ${sites[@]}"
+  echo "Hosts have been added for the following sites: ${sites[@]}"
 fi


### PR DESCRIPTION
The `tools/set_hosts.sh` script doesn't update the correct `/etc/hosts` file when running on Windows via WSL2.
This change means that it will detect if `C:\Windows\System32\drivers\etc\hosts` exists, and update it rather than WSL's `/etc/hosts`