### PR TITLE
Automatically detect the correct PHP container to use & allow specifying default containers for the tup command

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,22 +1,34 @@
 # Disable auto-updating of docker-dev by setting this to 0
 AUTO_UPDATE=1
+
 # set the path here to your local src path
 LOCAL_SRC=/your/totara/src/path
-# some defaults
-REMOTE_SRC=/var/www/totara/src
-REMOTE_DATA=/var/www/totara/data
-MYSQL_ROOT_PW=root
-MSSQL_SA_PW=Totara.Mssql1
+
+# Containers to start when the 'tup' command is run without any arguments
+# Like most CMSes, Totara requires a webserver, a database, and PHP
+# It is recommended to use nginx, and the latest version of postgres and PHP for better performance
+# Note that specifying just 'php' will automatically use the latest version of PHP that the Totara site supports
+DEFAULT_CONTAINERS=nginx,pgsql14,php
+
 # set this to your local IP address
 # for mac just use "host.docker.internal"
 # for linux run command "docker run --rm alpine ip -4 route list match 0/0 | cut -d' ' -f3" and use the resulting ip address
 # most probably it is 172.17.0.1
 HOST_IP=host.docker.internal
-# Build settings (this will have an affect on build only)
-TIME_ZONE=Pacific/Auckland
+
 # Uncomment and change the following to a full path on your host
 # If not specified tdb will use the folder "tdb_backup" in your home directory
-#TDB_BACKUP_PATH=~/your/path/to/backup/location
-# Set this to a region close to you for better page loading times
+#TDB_BACKUP_PATH=/your/path/to/backup/location
+
+# Set this to a region close to you for better page loading times when using ngrok
 # Available ngrok regions: us (Ohio), eu (Frankfurt), ap (Singapore), au (Sydney), sa (Sao Paulo), jp (Tokyo), in (Mumbai)
 NGROK_REGION=au
+
+# Build settings (this will have an affect on build only)
+TIME_ZONE=Pacific/Auckland
+
+# Defaults - you shouldn't really need to change these.
+REMOTE_SRC=/var/www/totara/src
+REMOTE_DATA=/var/www/totara/data
+MYSQL_ROOT_PW=root
+MSSQL_SA_PW=Totara.Mssql1

--- a/bin/helpers/php_container.php
+++ b/bin/helpers/php_container.php
@@ -19,6 +19,8 @@ $php_container_ids = !empty($php_container_ids) ? preg_split('/\s+/',$php_contai
 $php_container_names = trim(shell_exec('docker ps -aqf "name=^totara_php" --format "{{.Names}}"'));
 $php_container_names = !empty($php_container_names) ? preg_split('/\s+/', $php_container_names) : array();
 $php_containers_running = array_combine($php_container_ids, $php_container_names);
+asort($php_containers_running);
+$php_containers_running = array_reverse($php_containers_running);
 
 // Get all the possible containers that could be started
 $php_containers_matches = array();

--- a/bin/helpers/php_container.php
+++ b/bin/helpers/php_container.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * This is a helper script that gets the PHP container with the latest version that the Totara site supports,
+ * and starts it if it isn't already running.
+ */
+
+$docker_dev_root = dirname(dirname(__DIR__));
+
+if (empty($argv[1])) {
+    fwrite(fopen('php://stderr', 'wb'), "Must specify the totara site path as the first argument" . PHP_EOL);
+    exit(1);
+}
+$site_path = $argv[1];
+$silent = !empty($argv[2]) && strpos($argv[2], 'silent') !== false;
+
+// Gets the ID & Name of the latest PHP container that can be used for this Totara version
+$php_container_ids = trim(shell_exec('docker ps -aqf "name=^totara_php" --format "{{.ID}}"'));
+$php_container_ids = !empty($php_container_ids) ? preg_split('/\s+/',$php_container_ids) : array();
+$php_container_names = trim(shell_exec('docker ps -aqf "name=^totara_php" --format "{{.Names}}"'));
+$php_container_names = !empty($php_container_names) ? preg_split('/\s+/', $php_container_names) : array();
+$php_containers_running = array_combine($php_container_ids, $php_container_names);
+
+// Get all the possible containers that could be started
+$php_containers_matches = array();
+preg_match_all("/php-([0-9]\.[0-9])[^:]*:/", file_get_contents("$docker_dev_root/compose/php.yml"), $php_containers_matches);
+if (empty($php_containers_matches)) {
+    fwrite(fopen('php://stderr', 'wb'), "Fatal regex error" . PHP_EOL);
+    exit(1);
+}
+$php_containers_available = array_unique($php_containers_matches[1]);
+asort($php_containers_available);
+$php_containers_available = array_reverse($php_containers_available);
+
+// Get the versions to use from the site composer.json (if it exists)
+$matches = array();
+$composer_json = json_decode(file_get_contents("$site_path/composer.json"));
+if (isset($composer_json->require->php)) {
+    // Extract the PHP versions we can use for Totara
+    $versions = $composer_json->require->php;
+    preg_match_all('/(\D+)(\d\.\d)\S*\s(\D+)(\d\.\d)\S*/', $versions, $matches);
+    $min_comparator = $matches[1][0];
+    $min_version = $matches[2][0];
+    $max_comparator = $matches[3][0];
+    $max_version = $matches[4][0];
+} else {
+    // There isn't a composer json - this means moodle is running.
+    $min_comparator = '>=';
+    $min_version = '7.1';
+    $max_comparator = '<=';
+    $max_version = '7.3';
+}
+
+// See if any supported containers are currently running - it's faster to just use what is available than upping a new container.
+foreach ($php_containers_running as $container_id => $container_name) {
+    $matches = array();
+    preg_match_all('/php(\d)(\d)/', $container_name, $matches);
+    $container_version = $matches[1][0] . '.' . $matches[2][0];
+    if (version_compare($container_version, $min_version, $min_comparator) && version_compare($container_version, $max_version, $max_comparator)) {
+        if (!$silent) {
+            echo 'php-' . $container_version . ' ' . $container_id . ' ' . $container_version;
+        }
+        exit(0);
+    }
+}
+
+// No supported containers are currently running, so let's just start the container for the latest supported version of php.
+foreach ($php_containers_available as $container_version) {
+    if (version_compare($container_version, $min_version, $min_comparator) && version_compare($container_version, $max_version, $max_comparator)) {
+        shell_exec('tup php-' . $container_version);
+        $container_id = shell_exec('docker ps -aqf "name=^totara_php' . str_replace('.', '', $container_version) . '$"');
+
+        if (!$silent) {
+            echo 'php-' . $container_version . ' ' . $container_id . ' ' . $container_version;
+        }
+        exit(0);
+    }
+}
+
+exit(1);

--- a/bin/tbash
+++ b/bin/tbash
@@ -1,21 +1,39 @@
 #!/bin/bash
 
-SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
-PROJECTPATH="$( cd $SCRIPTPATH && cd ..; pwd -P )"
+script_path="$( cd "$(dirname "$0")" ; pwd -P )"
+project_path="$( cd $script_path && cd ..; pwd -P )"
 
-export $(egrep -v '^#' $PROJECTPATH/.env | xargs)
+export $(egrep -v '^#' $project_path/.env | xargs)
 
 # If this command is called from a subdirectory which contains a project, then we automatically change to this directory
-SUBPATH="${PWD//$LOCAL_SRC/}"
-TOTARASITEDIR="$REMOTE_SRC/$SUBPATH"
-LOCALPATH="$LOCAL_SRC/$SUBPATH"
-
-if [ ! -f "$LOCALPATH/version.php" ]; then
-    TOTARASITEDIR="$REMOTE_SRC"
+sub_path="${PWD//$LOCAL_SRC/}"
+local_path="$LOCAL_SRC/$sub_path"
+remote_path="$REMOTE_SRC/$sub_path"
+if [ ! -f "$local_path/version.php" ]; then
+    remote_path="$REMOTE_SRC"
 fi
 
-if [[ "$1" =~ "php" || "$1" =~ "nginx" || "$1" =~ "apache" ]]; then
-  $SCRIPTPATH/tdocker exec -w $TOTARASITEDIR "$1" /bin/bash
-else
-  $SCRIPTPATH/tdocker exec "$1" /bin/bash
+# If the container isn't specified, then we just default to the default php container.
+container="$1"
+if [[ -z "$container" ]]; then
+    container="php"
 fi
+
+# If just 'php' is specified, then dynamically work out which one to actually use based upon the site composer.json
+if [[ "$container" == "php" ]]; then
+    if [[ ! -f "$local_path/version.php" ]]; then
+        echo "This command must be run from a Totara site directory if 'php' is specified for the container"
+        exit 1
+    fi
+    php_container=($(php "$project_path/bin/helpers/php_container.php" "$local_path"))
+    container=${php_container[0]}
+    echo -e "\x1B[2mUsing PHP Container: $container\x1B[0m"
+fi
+
+# If we are bashing into php/apache/nginx, then lets make the shell begin in the remote directory
+extra_args=""
+if [[ "$container" =~ "php" || "$container" =~ "nginx" || "$container" =~ "apache" ]]; then
+    extra_args="-w $remote_path"
+fi
+
+$script_path/tdocker exec $extra_args "$container" /bin/bash

--- a/bin/tdb
+++ b/bin/tdb
@@ -3,8 +3,7 @@
 script_name=$(basename "$0")
 script_path="$( cd "$(dirname $0)" || exit; pwd -P )"
 project_path="$( cd "$script_path" && cd ..; pwd -P )"
-
-source "$project_path/tools/check_for_update.sh"
+helpers_path="$project_path/bin/helpers"
 
 export $(grep -E -v '^#' "$project_path/.env" | xargs)
 
@@ -88,63 +87,24 @@ else
 fi
 
 if [ ! -f "$local_dir/config.php" ]; then
-    echo -e "\x1B[33mCould not find a totara site (or a config.php)\nIf you have multiple sites, make sure you run this command from the correct directory.\x1B[0m"
+    echo -e "\x1B[33mCould not find a totara site (config.php is missing)\nIf you have multiple sites, make sure you run this command from the correct directory.\x1B[0m"
     exit
 fi
 
-# Get PHP Version to use based on totara version
-version_php_path="$local_dir/version.php"
-if [ -f "$local_dir/server/version.php" ]; then
-    version_php_path="$local_dir/server/version.php"
+# This next part gets the ID of the latest PHP container that can be used for this
+# Totara/Moodle version (from composer.json), and starts the container if it isn't already running.
+php_containers=($(php "$helpers_path/php_container.php" "$local_dir"))
+if [ -z "$php_containers" ]; then
+    echo -e "\x1B[33mUnable to determine (or start) the appropriate PHP container for this Totara version.\x1B[0m"
+    exit
 fi
-php_get_version_code="
-    \$matches=array();
-    \$totara_regex=\"/version[\s]*=[\s]*\'([^\']+)\'/\";
-    preg_match_all(\$totara_regex, file_get_contents('${version_php_path}'), \$matches);
-    if (!empty(\$matches) && isset(\$matches[1][0])) {
-        echo(\$matches[1][0]);
-        return;
-    }
-"
-totara_version=$(php -r "$php_get_version_code")
-if [[ "$totara_version" =~ '^2.' ]]; then
-    php_version='5.6'
-elif [[ "$totara_version" =~ '9.' ]]; then
-    php_version='7.0'
-elif [[ "$totara_version" =~ '10.' ]]; then
-    php_version='7.2'
-else
-    php_version='7.3'
-fi
-php_container_version=$(echo $php_version | sed 's/[^0-9]*//g')
-
-# Get running php container, or start it if it isn't running
-php_containers=($(docker ps --filter "name=php$php_container_version" --format '{{.ID}} {{.Names}}' | grep -v "_debug" | xargs))
-if [ -z $php_containers ]; then
-    tup "php-$php_version"
-    php_containers=($(docker ps --filter "name=php$php_container_version" --format '{{.ID}} {{.Names}}' | grep -v "_debug" | xargs))
-fi
-php_container=${php_containers[0]}
-php_container_name=${php_containers[1]}
+php_container=${php_containers[1]}
+php_container_name=${php_containers[0]}
 php_command="docker exec $php_container";
 
 # Get the database variables from the site config.php
-config_php_path="$remote_dir/config.php"
-if [ -f "$local_dir/server/config.php" ]; then
-    config_php_path="$remote_dir/server/config.php"
-fi
-php_get_config_vars="
-    define(\"CLI_SCRIPT\", true);
-    define(\"ABORT_AFTER_CONFIG\", true);
-    require_once(\"$config_php_path\");
-    if (!isset(\$CFG->dbtype) || !isset(\$CFG->dbhost) || !isset(\$CFG->dbname) || !isset(\$CFG->dbuser) || !isset(\$CFG->dbpass) || !isset(\$CFG->dataroot)) {
-        echo(0);
-        return;
-    }
-    echo \"1 \$CFG->dataroot \$CFG->dbtype \$CFG->dbhost \$CFG->dbname \$CFG->dbuser \$CFG->dbpass\";
-"
-
-config_output=$( eval "$php_command php -r '$php_get_config_vars'" )
+config_vars_to_get=("dataroot" "dbtype" "dbhost" "dbname" "dbuser" "dbpass")
+config_output=$( eval "$php_command /bin/zsh -i -c 'cd $remote_dir && config_var ${config_vars_to_get[@]}'" )
 
 # Show a relevant error message if there is an issue with the config php
 if [[ "$config_output" =~ "dataroot is not configured properly" ]]; then
@@ -156,26 +116,22 @@ elif [[ "$config_output" =~ "Parse error" ]]; then
 elif [[ "$config_output" =~ "Creating default object from empty value" ]]; then
     echo -e "\x1B[33mThe site config.php is is incompatible with this totara version.\nDouble check you've checked out the correct code and/or your config.php is correct.\x1B[0m"
     exit
-fi
-
-config_vars=($config_output)
-
-if [ "${config_vars[0]}" == '0' ]; then
+elif [[ -z "$config_output" ]]; then
     echo -e "\x1B[33mDatabase config variables are missing from config.php\x1B[0m"
     exit
 fi
 
-dataroot=${config_vars[1]}
-db_type=${config_vars[2]}
-db_host=${config_vars[3]}
-db_user=${config_vars[5]}
-db_password=${config_vars[6]}
+config_vars=($config_output)
+dataroot=${config_vars[0]}
+db_type=${config_vars[1]}
+db_host=${config_vars[2]}
+db_name=${config_vars[3]}
+db_user=${config_vars[4]}
+db_password=${config_vars[5]}
 
-# Get the db name. Defaults to what is defined in config.php
-if [ ! -z $2 ]; then
+# Second argument overrides the the db name
+if [[ -n $2 ]]; then
     db_name=$2
-else
-    db_name=${config_vars[4]}
 fi
 
 # Get the db container
@@ -252,7 +208,7 @@ if [[ $action == 'backup' || $action == 'restore' ]]; then
 
     # Dataroot backup functionality. For now we don't care about the phpunit/behat dataroots.
     # We only backup/restore the dataroot if we are backing up/restoring the site database.
-    if [[ "$ignore_dataroot" == "0" && "$db_name" == "${config_vars[4]}" ]]; then
+    if [[ "$ignore_dataroot" == "0" && "$db_name" == "${config_vars[3]}" ]]; then
         dataroot_name=$(basename "$dataroot")
         dataroot_dir=$(dirname "$dataroot")
         backup_dataroot_suffix=".dataroot.zip";
@@ -265,6 +221,7 @@ if [[ $action == 'backup' || $action == 'restore' ]]; then
             exit
         # If restoring, make sure the backup dataroot zip exists.
         elif [[ $action == 'restore' && ! -f "$backup_dataroot_local" ]]; then
+            ignore_dataroot="1"
             echo -e "\x1B[33mWARNING: Backup dataroot zip does not exist at '$backup_dataroot_local'\n         This may cause uploaded files, caches and other non-database objects to not work correctly.\x1B[0m"
         fi
     fi

--- a/bin/tup
+++ b/bin/tup
@@ -1,27 +1,57 @@
 #!/bin/bash
 
-SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
-PROJECTPATH="$( cd $SCRIPTPATH && cd ..; pwd -P )"
+script_path="$( cd "$(dirname "$0")" ; pwd -P )"
+project_path="$( cd $script_path && cd ..; pwd -P )"
+export $(egrep -v '^#' $project_path/.env | xargs)
+
+# Handle subdirectory
+local_dir="$LOCAL_SRC"
+sub_path="${PWD//$LOCAL_SRC/}"
+if [ -n "$sub_path" ]; then
+    local_dir="${LOCAL_SRC}/${sub_path}"
+fi
+
+containers=("$@")
+if [ -z $containers ]; then
+    if [ -z $DEFAULT_CONTAINERS ]; then
+        echo "DEFAULT_CONTAINERS is not set in your docker-dev .env file, so at least one container must be specified"
+        exit 1
+    fi
+    containers=(${DEFAULT_CONTAINERS//,/ })
+fi
+
+containers_to_start=()
+for container in "${containers[@]}"; do
+    if [[ "$container" == "php" ]]; then
+        if [[ ! -f "$local_dir/version.php" ]]; then
+            echo "tup must be run from a Totara site directory if the 'php' container is specified"
+            exit 1
+        fi
+        php_container=($(php "$project_path/bin/helpers/php_container.php" "$local_dir"))
+        containers_to_start+=(${php_container[0]})
+    else
+        containers_to_start+=("$container")
+    fi
+done
+
+# Always start up the sync container for mutagen
+if [ -f "$project_path/.use-mutagen" ]; then
+    containers_to_start+=("sync")
+fi
+
+$script_path/tdocker up -d "${containers_to_start[@]}"
 
 # if mutagen should be used make sure it's started
-if [ -f "$PROJECTPATH/.use-mutagen" ]
-then
-    # Always start up the sync container for mutagen
-    $SCRIPTPATH/tdocker up -d sync "$@"
-
-    export $(egrep -v '^#' $PROJECTPATH/.env | xargs)
-
+if [ -f "$project_path/.use-mutagen" ]; then
     # check if there's already a session
     mutagen list | grep "$REMOTE_SRC" &> /dev/null
 
     if [ $? != 0 ]; then
-       mutagen sync create \
-            -c $PROJECTPATH/mutagen.yml \
+        mutagen sync create \
+            -c $project_path/mutagen.yml \
             -n totara \
             $LOCAL_SRC docker://totara_sync$REMOTE_SRC
     else
         mutagen sync resume totara
     fi
-else
-    $SCRIPTPATH/tdocker up -d "$@"
 fi

--- a/bin/tzsh
+++ b/bin/tzsh
@@ -1,17 +1,32 @@
 #!/bin/bash
 
-SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
-PROJECTPATH="$( cd $SCRIPTPATH && cd ..; pwd -P )"
+script_path="$( cd "$(dirname "$0")" ; pwd -P )"
+project_path="$( cd $script_path && cd ..; pwd -P )"
 
-export $(egrep -v '^#' $PROJECTPATH/.env | xargs)
+export $(egrep -v '^#' $project_path/.env | xargs)
 
 # If this command is called from a subdirectory which contains a project, then we automatically change to this directory
-SUBPATH="${PWD//$LOCAL_SRC/}"
-TOTARASITEDIR="$REMOTE_SRC/$SUBPATH"
-LOCALPATH="$LOCAL_SRC/$SUBPATH"
-
-if [ ! -f "$LOCALPATH/version.php" ]; then
-    TOTARASITEDIR="$REMOTE_SRC"
+sub_path="${PWD//$LOCAL_SRC/}"
+local_path="$LOCAL_SRC/$sub_path"
+remote_path="$REMOTE_SRC/$sub_path"
+if [ ! -f "$local_path/version.php" ]; then
+    remote_path="$REMOTE_SRC"
 fi
 
-$SCRIPTPATH/tdocker exec -w $TOTARASITEDIR "$1" /bin/zsh
+container="$1"
+if [[ ! "$container" =~ "php" ]]; then
+    echo "tzsh only supports php containers"
+    exit 1
+fi
+
+# If just 'php' is specified, then dynamically work out which one to actually use based upon the site composer.json
+if [[ "$container" == "php" ]]; then
+    if [[ ! -f "$local_path/version.php" ]]; then
+        echo "This command must be run from a Totara site directory if 'php' is specified for the container"
+        exit 1
+    fi
+    php_container=($(php "$project_path/bin/helpers/php_container.php" "$local_path"))
+    container=${php_container[0]}
+fi
+
+$script_path/tdocker exec -w $remote_path "$container" /bin/zsh


### PR DESCRIPTION
When going back to older Totara versions, it can be annoying to find out what the correct PHP version should be used. With this change, you can simply run `tup php` from the totara site root, and it will automatically detect what the min and max PHP versions are, and then up the appropriate container. This also works when using the `tbash`, `tzsh`, and `tdb` commands.

This also adds the ability to specify a default set of containers to use when just running `tup`. Currently when running `tup` without any arguments, it will attempt to start every container which is not what anyone would really want. The `DEFAULT_CONTAINERS` variable in `.env` will be used (e.g. `DEFAULT_CONTAINERS=nginx,pgsql13,php-8.0`) to work out what should be started.