### PR TITLE
Feature improve postgres drop behaviour

### DIFF
--- a/bin/tdb
+++ b/bin/tdb
@@ -287,11 +287,13 @@ if [ "$db_type" == 'pgsql' ]; then
 
     # Drop and create pgsql database
     elif [ "$action" == 'recreate' ]; then
+        $db_command psql -U "$db_user" -o /dev/null -c "SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity WHERE pg_stat_activity.datname = '$db_name'"
         $db_command dropdb -U "$db_user" --if-exists "$db_name"
         $db_command createdb -U "$db_user" -T template1 -E UTF-8 "$db_name"
 
     # Drop pgsql database
     elif [ "$action" == 'drop' ]; then
+        $db_command psql -U "$db_user" -o /dev/null -c "SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity WHERE pg_stat_activity.datname = '$db_name'"
         $db_command dropdb -U "$db_user" "$db_name"
 
     # Backup pgsql database
@@ -305,6 +307,7 @@ if [ "$db_type" == 'pgsql' ]; then
     # Restore pgsql database
     elif [ "$action" == 'restore' ]; then
         docker cp "$backup_file_local" "$db_container":"$backup_file_remote"
+        $db_command psql -U "$db_user" -o /dev/null -c "SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity WHERE pg_stat_activity.datname = '$db_name'"
         $db_command dropdb -U "$db_user" --if-exists "$db_name"
         $db_command createdb -U "$db_user" -T template1 -E UTF-8 "$db_name"
         if [ "$for_totara_box" == "1" ]; then


### PR DESCRIPTION
My workflow is to have a terminal tab open with a postgres shell (via tdb shell) open at all times. However when you run a tdb command that drops a database it fails if there is an existing session.

This PR triggers a postgres statement which will kill any existing sessions allowing the database drop to proceed.

In the session that's been dropped, if you execute another command after the session was killed you get an error:

```
FATAL:  terminating connection due to administrator command
server closed the connection unexpectedly
	This probably means the server terminated abnormally
	before or while processing the request.
The connection to the server was lost. Attempting reset: Succeeded.
```

but then it auto-reconnects and you can just repeat the command from history.
