### PR TITLE
Add missing packages for PHP images and upgrade Xdebug to version 3

### DIFF
--- a/compose/build.yml
+++ b/compose/build.yml
@@ -115,6 +115,12 @@ services:
   php-8.0-cron:
     build: ./php/php80-cron
 
+  php-8.0-debug:
+    build: ./php/php80-debug
+
+  php-8.0-cron:
+    build: ./php/php80-cron
+
   php-8.1:
     build:
       context: ./php/php81

--- a/compose/php.yml
+++ b/compose/php.yml
@@ -328,7 +328,8 @@ services:
     environment:
       CONTAINERNAME: php-7.2-debug
       TZ: ${TIME_ZONE}
-      XDEBUG_CONFIG: remote_host=${HOST_IP}
+      XDEBUG_CONFIG: client_host=${HOST_IP}
+      XDEBUG_SESSION: totara72
       PHP_IDE_CONFIG: serverName=totara72
       HIST_FILE: /root/.bash_history
       DISABLE_AUTO_UPDATE: "true" # disables oh-my-zsh update message
@@ -380,7 +381,8 @@ services:
     environment:
       CONTAINERNAME: php-7.3-debug
       TZ: ${TIME_ZONE}
-      XDEBUG_CONFIG: remote_host=${HOST_IP}
+      XDEBUG_CONFIG: client_host=${HOST_IP}
+      XDEBUG_SESSION: totara73
       PHP_IDE_CONFIG: serverName=totara73
       HIST_FILE: /root/.bash_history
       DISABLE_AUTO_UPDATE: "true" # disables oh-my-zsh update message
@@ -432,7 +434,8 @@ services:
     environment:
       CONTAINERNAME: php-7.4-debug
       TZ: ${TIME_ZONE}
-      XDEBUG_CONFIG: remote_host=${HOST_IP}
+      XDEBUG_CONFIG: client_host=${HOST_IP}
+      XDEBUG_SESSION: totara74
       PHP_IDE_CONFIG: serverName=totara74
       HIST_FILE: /root/.bash_history
       DISABLE_AUTO_UPDATE: "true" # disables oh-my-zsh update message
@@ -463,6 +466,29 @@ services:
     working_dir: ${REMOTE_SRC}
     environment:
       CONTAINERNAME: php-8.0
+      HIST_FILE: /root/.bash_history
+      DISABLE_AUTO_UPDATE: "true" # disables oh-my-zsh update message
+    volumes:
+      - ${LOCAL_SRC}:${REMOTE_SRC}
+      - totara-data:${REMOTE_DATA}
+      - $HOME/.bash_history:/root/.bash_history
+      - zsh-history:/root/.zsh_history
+      - ./shell:/root/custom_shell
+    depends_on:
+      - php-8.0-debug
+    networks:
+      - totara
+
+  php-8.0-debug:
+    image: totara/docker-dev-php80-debug
+    container_name: totara_php80_debug
+    working_dir: ${REMOTE_SRC}
+    environment:
+      CONTAINERNAME: php-8.0-debug
+      TZ: ${TIME_ZONE}
+      XDEBUG_CONFIG: client_host=${HOST_IP}
+      XDEBUG_SESSION: totara80
+      PHP_IDE_CONFIG: serverName=totara80
       HIST_FILE: /root/.bash_history
       DISABLE_AUTO_UPDATE: "true" # disables oh-my-zsh update message
     volumes:

--- a/compose/sync.yml
+++ b/compose/sync.yml
@@ -109,7 +109,19 @@ services:
     volumes:
       - totara-www-sync:${REMOTE_SRC}:nocopy
 
+  php-8.0:
+    volumes:
+      - totara-www-sync:${REMOTE_SRC}:nocopy
+
+  php-8.0-debug:
+    volumes:
+      - totara-www-sync:${REMOTE_SRC}:nocopy
+
   nodejs:
+    volumes:
+      - totara-www-sync:${REMOTE_SRC}:nocopy
+
+  php-8.0-cron:
     volumes:
       - totara-www-sync:${REMOTE_SRC}:nocopy
 

--- a/php/php72-debug/Dockerfile
+++ b/php/php72-debug/Dockerfile
@@ -1,6 +1,6 @@
 FROM totara/docker-dev-php72:latest
 
-RUN pecl install -f xdebug-2.9.6 && docker-php-ext-enable xdebug.so
+RUN pecl install -f xdebug-3.1.1 && docker-php-ext-enable xdebug.so
 
-RUN echo "xdebug.remote_enable=1" >> /usr/local/etc/php/conf.d/xdebug.ini \
-    && echo "xdebug.remote_autostart=0" >> /usr/local/etc/php/conf.d/xdebug.ini
+RUN echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
+    && echo "xdebug.start_with_request=trigger" >> /usr/local/etc/php/conf.d/xdebug.ini

--- a/php/php72/Dockerfile
+++ b/php/php72/Dockerfile
@@ -28,7 +28,8 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         ghostscript \
         graphviz \
         aspell \
-    && rm -rf /var/lib/apt/lists/* \
+        libldap2-dev \
+    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
     && docker-php-ext-install -j$(nproc) xmlrpc \
         zip \
         intl \
@@ -39,12 +40,14 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         pgsql \
         mysqli \
         exif \
+        ldap \
     && docker-php-ext-configure gd \
             --with-freetype-dir=/usr/include/ \
             --with-png-dir=/usr/include/ \
             --with-jpeg-dir=/usr/include/ \
             --with-gd \
-    && docker-php-ext-install -j$(nproc) gd
+    && docker-php-ext-install -j$(nproc) gd \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN git clone https://github.com/tideways/php-profiler-extension.git \
     && cd php-profiler-extension \
@@ -102,6 +105,13 @@ RUN docker-php-ext-enable sqlsrv.so && docker-php-ext-enable pdo_sqlsrv.so
 
 RUN ln -fs /usr/share/zoneinfo/${TIME_ZONE} /etc/localtime \
     && dpkg-reconfigure --frontend noninteractive tzdata
+
+# Python 3.7 for ML Recommender.
+RUN apt-get update && apt install -y python3.7 \
+    python3-pip \
+    python3-wheel \
+    python3-venv \
+    python3-dev
 
 COPY config/php.ini /usr/local/etc/php/
 COPY config/fpm.conf /usr/local/etc/php-fpm.d/zz-totara.conf

--- a/php/php73-debug/Dockerfile
+++ b/php/php73-debug/Dockerfile
@@ -1,6 +1,6 @@
 FROM totara/docker-dev-php73:latest
 
-RUN pecl install -f xdebug-2.9.6 && docker-php-ext-enable xdebug.so
+RUN pecl install -f xdebug-3.1.1 && docker-php-ext-enable xdebug.so
 
-RUN echo "xdebug.remote_enable=1" >> /usr/local/etc/php/conf.d/xdebug.ini \
-    && echo "xdebug.remote_autostart=0" >> /usr/local/etc/php/conf.d/xdebug.ini
+RUN echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
+    && echo "xdebug.start_with_request=trigger" >> /usr/local/etc/php/conf.d/xdebug.ini

--- a/php/php73/Dockerfile
+++ b/php/php73/Dockerfile
@@ -28,7 +28,8 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         ghostscript \
         graphviz \
         aspell \
-    && rm -rf /var/lib/apt/lists/* \
+        libldap2-dev \
+    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
     && docker-php-ext-install -j$(nproc) xmlrpc \
         zip \
         intl \
@@ -39,12 +40,14 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         pgsql \
         mysqli \
         exif \
+        ldap \
     && docker-php-ext-configure gd \
             --with-freetype-dir=/usr/include/ \
             --with-png-dir=/usr/include/ \
             --with-jpeg-dir=/usr/include/ \
             --with-gd \
-    && docker-php-ext-install -j$(nproc) gd
+    && docker-php-ext-install -j$(nproc) gd \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN git clone https://github.com/tideways/php-profiler-extension.git \
     && cd php-profiler-extension \
@@ -103,6 +106,13 @@ RUN docker-php-ext-enable sqlsrv.so && docker-php-ext-enable pdo_sqlsrv.so
 RUN ln -fs /usr/share/zoneinfo/${TIME_ZONE} /etc/localtime \
     && dpkg-reconfigure --frontend noninteractive tzdata
 
+# Python 3.7 for ML Recommender.
+RUN apt-get update && apt install -y python3.7 \
+    python3-pip \
+    python3-wheel \
+    python3-venv \
+    python3-dev
+
 COPY config/php.ini /usr/local/etc/php/
 COPY config/fpm.conf /usr/local/etc/php-fpm.d/zz-totara.conf
 
@@ -119,10 +129,3 @@ RUN git clone https://github.com/zsh-users/zsh-syntax-highlighting ~/.oh-my-zsh/
 RUN echo 'setopt +o nomatch' > ~/.zshrc
 RUN echo 'source ~/custom_shell/.zshrc' >> ~/.zshrc
 RUN cat ~/.bashrc >> ~/.zshrc
-
-# Python 3.7 for ML Recommender.
-RUN apt install -y python3.7 \
-    python3-pip \
-    python3-wheel \
-    python3-venv \
-    python3-dev

--- a/php/php74/Dockerfile
+++ b/php/php74/Dockerfile
@@ -26,6 +26,8 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         ghostscript \
         graphviz \
         aspell \
+        libldap2-dev \
+    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
     && docker-php-ext-install -j$(nproc) xmlrpc \
         zip \
         intl \
@@ -36,6 +38,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         pgsql \
         mysqli \
         exif \
+        ldap \
     && docker-php-ext-configure gd \
             --with-freetype \
             --with-jpeg \
@@ -52,6 +55,10 @@ RUN echo "extension=tideways_xhprof.so" >> /usr/local/etc/php/conf.d/tideways_xh
 RUN pecl install -o -f redis \
     &&  rm -rf /tmp/pear \
     &&  docker-php-ext-enable redis
+
+RUN pecl install -o -f igbinary \
+    &&  rm -rf /tmp/pear \
+    &&  docker-php-ext-enable igbinary
 
 RUN pecl install -o -f memcached \
     &&  rm -rf /tmp/pear \
@@ -94,7 +101,7 @@ RUN ln -fs /usr/share/zoneinfo/${TIME_ZONE} /etc/localtime \
     && dpkg-reconfigure --frontend noninteractive tzdata
 
 # Python 3.7 for ML Recommender.
-RUN apt install -y python3.7 \
+RUN apt-get update && apt install -y python3.7 \
     python3-pip \
     python3-wheel \
     python3-venv \

--- a/php/php80-debug/Dockerfile
+++ b/php/php80-debug/Dockerfile
@@ -1,4 +1,4 @@
-FROM totara/docker-dev-php74:latest
+FROM totara/docker-dev-php80:latest
 
 RUN pecl install -f xdebug-3.1.1 && docker-php-ext-enable xdebug.so
 

--- a/php/php80/Dockerfile
+++ b/php/php80/Dockerfile
@@ -26,6 +26,8 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         ghostscript \
         graphviz \
         aspell \
+        libldap2-dev \
+    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
     && docker-php-ext-install -j$(nproc) zip \
         intl \
         soap \
@@ -35,9 +37,10 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         pgsql \
         mysqli \
         exif \
+        ldap \
     && docker-php-ext-configure gd \
-                --with-freetype \
-                --with-jpeg \
+            --with-freetype \
+            --with-jpeg \
     && docker-php-ext-install -j$(nproc) gd
 
 RUN git clone https://github.com/tideways/php-profiler-extension.git \
@@ -47,6 +50,18 @@ RUN git clone https://github.com/tideways/php-profiler-extension.git \
     && make && make install
 
 RUN echo "extension=tideways_xhprof.so" >> /usr/local/etc/php/conf.d/tideways_xhprof.ini
+
+RUN pecl install -o -f redis \
+    &&  rm -rf /tmp/pear \
+    &&  docker-php-ext-enable redis
+
+RUN pecl install -o -f igbinary \
+    &&  rm -rf /tmp/pear \
+    &&  docker-php-ext-enable igbinary
+
+RUN pecl install -o -f memcached \
+    &&  rm -rf /tmp/pear \
+    &&  docker-php-ext-enable memcached
 
 # we need en_US locales for MSSQL connection to work
 # we need en_AU locales for behat to work
@@ -83,6 +98,13 @@ RUN docker-php-ext-enable sqlsrv.so && docker-php-ext-enable pdo_sqlsrv.so
 
 RUN ln -fs /usr/share/zoneinfo/${TIME_ZONE} /etc/localtime \
     && dpkg-reconfigure --frontend noninteractive tzdata
+
+# Python 3.7 for ML Recommender.
+RUN apt-get update && apt install -y python3.7 \
+    python3-pip \
+    python3-wheel \
+    python3-venv \
+    python3-dev
 
 COPY config/php.ini /usr/local/etc/php/
 COPY config/fpm.conf /usr/local/etc/php-fpm.d/zz-totara.conf

--- a/php/php80/config/php.ini
+++ b/php/php80/config/php.ini
@@ -8,3 +8,16 @@ memory_limit=256M
 max_execution_time=120
 post_max_size = 64M
 upload_max_filesize = 64M
+
+# Turn on the OPcache for command-line PHP, like drush or
+# wp-cli, etc.
+opcache.enable_cli=1
+
+# The amount of shared memory to reserve for compiled JIT
+# code. A zero value disables the JIT.
+opcache.jit_buffer_size=50M
+
+# JIT control options. Either accepts a string or a 4 digit
+# int for advanced controls. See
+# https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.jit
+opcache.jit=tracing


### PR DESCRIPTION
PHP 8 was buggy for MacOS (did not make use of mutagen) and also some packages (ldap for example) were missing.

This also upgrades xdebug to 3.1.1 where possible