### PR TITLE
Use consistent permissions across all dataroot directories

### DIFF
--- a/bin/tdb
+++ b/bin/tdb
@@ -517,9 +517,21 @@ elif [ "$action" == 'restore' ]; then
         $php_command sh -c "\
             cd $dataroot_dir && \
             rm -rf $dataroot_name && \
-            mkdir $dataroot_name && \
-            chmod 02777 $dataroot_name -R && \
-            cd $dataroot_name && \
+            mkdir $dataroot_name" >> /dev/null
+
+        # We have to chmod using PHP. If we were to export the integer value it'll get interpreted
+        # as an octal and won't work. See https://www.php.net/manual/en/function.chmod.php for more info.
+        php_chmod_code="
+            define(\"CLI_SCRIPT\", true);
+            define(\"ABORT_AFTER_CONFIG\", true);
+            require(\"config.php\");
+            \$permissions = isset(\$CFG->directorypermissions) ? \$CFG->directorypermissions : 02777;
+            chmod(\"$dataroot_dir/$dataroot_name\", \$permissions);
+        "
+        $php_command sh -c "cd $remote_dir && php -r '$php_chmod_code'"
+
+        $php_command sh -c "\
+            cd $dataroot_dir/$dataroot_name && \
             unzip $backup_dataroot_remote && \
             chown www-data:www-data . -R \
         " >> /dev/null

--- a/config.php
+++ b/config.php
@@ -98,6 +98,9 @@ $CFG->prefix = 'ttr_';
 //$CFG->prefix = 'mdl_';
 //$CFG->prefix = 'bht_';
 
+
+$CFG->directorypermissions = 02777;
+
 /**
  * Dataroot: For storing uploaded files, temporary and cache files, and other miscellaneous files created by Totara.
  */
@@ -106,10 +109,8 @@ $CFG->dataroot = "/var/www/totara/data/{$DOCKER_DEV->site_name}.{$CFG->dbhost}";
 //$CFG->dataroot = '/var/www/totara/data/mobile.mysql';
 //$CFG->dataroot = '/var/www/totara/data/engage.mssql';
 if (!is_dir($CFG->dataroot)) {
-    @mkdir($CFG->dataroot) && @chgrp($CFG->dataroot, 'www-data') && @chown($CFG->dataroot, 'www-data');
+    @mkdir($CFG->dataroot, $CFG->directorypermissions) && @chgrp($CFG->dataroot, 'www-data') && @chown($CFG->dataroot, 'www-data');
 }
-
-$CFG->directorypermissions = 02777;
 
 /**
  * You shouldn't really need to change these.
@@ -197,7 +198,7 @@ $CFG->phpunit_prefix = 'phpu_';
  */
 $CFG->phpunit_dataroot = "/var/www/totara/data/{$DOCKER_DEV->site_name}.{$CFG->dbhost}.{$DOCKER_DEV->major_version}.phpunit";
 if (!is_dir($CFG->phpunit_dataroot)) {
-    @mkdir($CFG->phpunit_dataroot) && @chgrp($CFG->phpunit_dataroot, 'www-data') && @chown($CFG->phpunit_dataroot, 'www-data');
+    @mkdir($CFG->phpunit_dataroot, $CFG->directorypermissions) && @chgrp($CFG->phpunit_dataroot, 'www-data') && @chown($CFG->phpunit_dataroot, 'www-data');
 }
 
 
@@ -251,7 +252,7 @@ $CFG->behat_prefix = 'bht_';
  */
 $CFG->behat_dataroot = "/var/www/totara/data/{$DOCKER_DEV->site_name}.{$CFG->dbhost}.{$DOCKER_DEV->major_version}.behat";
 if (!is_dir($CFG->behat_dataroot)) {
-    @mkdir($CFG->behat_dataroot) && @chgrp($CFG->behat_dataroot, 'www-data') && @chown($CFG->behat_dataroot, 'www-data');
+    @mkdir($CFG->behat_dataroot, $CFG->directorypermissions) && @chgrp($CFG->behat_dataroot, 'www-data') && @chown($CFG->behat_dataroot, 'www-data');
 }
 
 //<editor-fold desc="Advanced behat setup" defaultstate="collapsed">


### PR DESCRIPTION
This makes it so that when dataroot folders are created, they depend on the `$CFG->directorypermissions` value set in the site config.php. This value is now also used when restoring dataroot backups via `tdb`. Resolves #112 