### PR TITLE
Disable the JIT compiler on PHP 8.0

### DIFF
--- a/php/php80/config/php.ini
+++ b/php/php80/config/php.ini
@@ -9,15 +9,17 @@ max_execution_time=120
 post_max_size = 64M
 upload_max_filesize = 64M
 
-# Turn on the OPcache for command-line PHP, like drush or
-# wp-cli, etc.
+# Turn on the OPcache for command-line PHP
 opcache.enable_cli=1
+
+# JIT support for Totara is still experimental and not fully functional yet
+# and therefore disabled by default:
 
 # The amount of shared memory to reserve for compiled JIT
 # code. A zero value disables the JIT.
-opcache.jit_buffer_size=50M
+;opcache.jit_buffer_size=50M
 
 # JIT control options. Either accepts a string or a 4 digit
 # int for advanced controls. See
 # https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.jit
-opcache.jit=tracing
+;opcache.jit=tracing


### PR DESCRIPTION
this still causes problems and should be treated as experimental so disabling it for now.