### PR TITLE
Add support for parallel PHPUnit execution to existing PHPUnit alias functions

### DIFF
--- a/shell/.zshrc
+++ b/shell/.zshrc
@@ -25,63 +25,26 @@ POWERLEVEL9K_CUSTOM_CONTAINER="zsh_php_container_name"
 POWERLEVEL9K_CUSTOM_CONTAINER_BACKGROUND="103"
 POWERLEVEL9K_CUSTOM_CONTAINER_FOREGROUND="black"
 
-get_server_dir() {
-    if [[ -f "./server/config.php" ]]; then
-        totara_dir='server/'
-    else
-        totara_dir=''
-    fi
-}
-
 # Shows the DB host if there is a config.php in the directory.
 zsh_db_host(){
-    get_server_dir
-    [[ -f "config.php" ]] || exit
-    local get_db_code="
-        define(\"CLI_SCRIPT\", true);
-        define(\"ABORT_AFTER_CONFIG\", true);
-        require_once(\"${totara_dir}config.php\");
-        if (isset(\$CFG->dbhost)) {
-            echo(\$CFG->dbhost);
-        } else {
-            echo(0);
-        }
-    "
-    local dbhost=`php -r "$get_db_code"`
+    is_site_root || exit
+    local dbhost=$(config_var dbhost)
     if [[ "$dbhost" =~ "error" || "$dbhost" =~ "Warning" || "$dbhost" =~ "Notice" ]]; then
-        echo -n '\uf071 Incompatible PHP version or invalid config.php!'
+        print_error 'Incompatible PHP version or invalid config.php!'
         exit
     fi
-    [[ "$dbhost" == '0' ]] && exit
     local dbicon='\uf1c0'
     echo -n "${dbicon} ${dbhost}"
 }
 POWERLEVEL9K_CUSTOM_DB="zsh_db_host"
-POWERLEVEL9K_CUSTOM_DB_BACKGROUND="006"
+POWERLEVEL9K_CUSTOM_DB_BACKGROUND="043"
 POWERLEVEL9K_CUSTOM_DB_FOREGROUND="black"
 
 # Shows the totara site version if there is a config.php/version.php in the directory.
 zsh_totara_version(){
-    get_server_dir
-    [[ -f "${totara_dir}config.php" && -f "${totara_dir}version.php" ]] || exit
-    local get_version_code="
-        \$matches=array();
-        \$totara_regex=\"/version[\s]*=[\s]*\'([^\']+)\'/\";
-        preg_match_all(\$totara_regex, file_get_contents('${totara_dir}version.php'), \$matches);
-        if (!empty(\$matches) && isset(\$matches[1][0])) {
-            echo('t' . \$matches[1][0]);
-            return;
-        }
-        \$moodle_regex=\"/release[\s]*=[\s]*\'([^\s]+)[^\']+\'/\";
-        preg_match_all(\$moodle_regex, file_get_contents('${totara_dir}version.php'), \$matches);
-        if (!empty(\$matches) && isset(\$matches[1][0])) {
-            echo('moodle ' . \$matches[1][0]);
-        }
-    "
-    local version=$(php -r "$get_version_code")
-    [[ -z "$version" ]] && exit
+    is_site_root || exit
     local totaraicon='\uf829'
-    echo -n "${totaraicon} ${version}"
+    echo -n "${totaraicon} $(totara_version)"
 }
 POWERLEVEL9K_CUSTOM_TOTARA="zsh_totara_version"
 POWERLEVEL9K_CUSTOM_TOTARA_BACKGROUND="106"

--- a/shell/default-aliases.sh
+++ b/shell/default-aliases.sh
@@ -125,17 +125,27 @@ purge() {
 
 # Initialise PHPUnit
 install_phpunit() {
-  # TODO: Add parallel support
-  run_totara_cmd php admin/tool/phpunit/cli/init.php $@
+  args=${*/parallel/processes}
+  if [[ "$args" =~ "processes" ]]; then
+    run_totara_cmd php admin/tool/phpunit/cli/parallel_init.php $args
+  else
+    run_totara_cmd php admin/tool/phpunit/cli/init.php $@
+  fi
 }
 alias installunit='install_phpunit'
 
 # Run PhpUnit
 phpunit() {
-  # TODO: Add parallel support
   site_root || return 1
+  args=${*/parallel/processes}
   if [[ -d './test/phpunit' ]]; then
-    run_cmd test/phpunit/vendor/bin/phpunit --configuration='test/phpunit/phpunit.xml' --test-suffix='test.php' $@
+    if [[ "$args" =~ "processes" ]]; then
+      run_totara_cmd php admin/tool/phpunit/cli/parallel_run.php --configuration='test/phpunit/phpunit.xml' $args
+    else
+      run_cmd test/phpunit/vendor/bin/phpunit --configuration='test/phpunit/phpunit.xml' --test-suffix='test.php' $@
+    fi
+  elif [[ "$args" =~ "processes" ]]; then
+    run_totara_cmd php admin/tool/phpunit/cli/parallel_run.php --configuration='phpunit.xml' $args
   else
     run_cmd vendor/bin/phpunit --configuration='phpunit.xml' --test-suffix='test.php' $@
   fi

--- a/shell/default-aliases.sh
+++ b/shell/default-aliases.sh
@@ -9,7 +9,8 @@ print_info() {
 
 # Echo a message with error colours (orange)
 print_error() {
-  echo -e "\x1B[33m$1\x1B[0m"
+  echo -e "\x1B[33m$1\x1B[0m" >&2
+  return 1
 }
 
 # Echo a command and then execute it
@@ -29,19 +30,24 @@ run_totara_cmd() {
   fi
 }
 
+# Is this directory the root of a Totara/Moodle site?
+is_site_root() {
+  [[ -f './config.php' && -f './version.php' ]] && return 0 || return 1
+}
+
 # cd into the root directory of the Totara site, or print an error message if it couldn't be found.
 site_root() {
   local original_path=$(pwd)
   local current_path="$original_path"
-  while [[ (! -f './config.php' || ( -f './config.php' && -f '../config.php' ))
-           && "$current_path" =~ "/var/www/totara/src" && "$current_path" != "/var/www/totara/src" ]]
+  while [[ ! -f './config.php' || -f './config.php' && -f '../config.php' ]] &&
+        [[ "$current_path" =~ "/var/www/totara/src" && "$current_path" != "/var/www/totara/src" ]]
   do
     cd ..
     current_path=$(pwd)
   done
-  if [ -f './config.php' ]; then
-    if [ "$current_path" != "$original_path" ]; then
-      echo -e "\x1B[2mChanged directory to \x1B[4m$current_path\x1B[0m"
+  if is_site_root; then
+    if [[ "$current_path" != "$original_path" ]]; then
+      echo -e "\x1B[2mChanged directory to \x1B[4m$current_path\x1B[0m" >&2
     fi
     return 0
   else
@@ -72,25 +78,30 @@ config_var() {
   php -r "$php_code" $@
 }
 
-# Get the major Totara/Moodle version, e.g. '13' or '2.9'
+# Get the Totara/Moodle version, e.g. '14.2dev' or '2.9.3'
+# Specify 'major' as the first argument to get just the major version, e.g. '14' or '2.9'
 totara_version() {
+  site_root || return 1
   local php_code="
-    \$version_file = @file_get_contents(\"./server/version.php\") ?: file_get_contents(\"./version.php\");
+    \$version_file = file_get_contents(\"./version.php\");
     \$totara_version_matches = \$moodle_version_matches = array();
     preg_match(\"/TOTARA->version[\s]*=[\s]*'([^']+)'/\", \$version_file, \$totara_version_matches);
     preg_match(\"/release[\s]*=[\s]*'([\S]+)[^']+'/\", \$version_file, \$moodle_version_matches);
     \$version = end(\$totara_version_matches) ?: end(\$moodle_version_matches);
-    echo preg_replace(\"/^(\d{2}|[1-8]\.\d|9).+$/\", \"\$1\", \$version);
   "
-  php -r "$php_code"
+  if [[ "$1" == "major" ]]; then
+    php -r "$php_code echo preg_replace(\"/^(\d{2}|[1-8]\.\d|9).+$/\", \"\$1\", \$version);"
+  else
+    php -r "$php_code echo \$version;"
+  fi
 }
 
 # Perform a fresh install of Totara
 install() {
   site_root || return 1
-  if [ -z "$1" ]; then
+  if [[ -z "$1" ]]; then
     # Make the site name the version of the Totara site
-    local site_name="Totara `totara_version` development site"
+    local site_name="Totara $(totara_version major) development site"
     run_totara_cmd php admin/cli/install_database.php --adminpass=admin --adminemail=admin@example.com --agree-license --shortname=$site_name --fullname=$site_name
   else
     run_totara_cmd php admin/cli/install_database.php $@
@@ -113,21 +124,23 @@ purge() {
 }
 
 # Initialise PHPUnit
-installunit() {
+install_phpunit() {
   # TODO: Add parallel support
   run_totara_cmd php admin/tool/phpunit/cli/init.php $@
 }
+alias installunit='install_phpunit'
 
 # Run PhpUnit
-unit() {
+phpunit() {
   # TODO: Add parallel support
   site_root || return 1
-  if [ -d './test/phpunit' ]; then
+  if [[ -d './test/phpunit' ]]; then
     run_cmd test/phpunit/vendor/bin/phpunit --configuration='test/phpunit/phpunit.xml' --test-suffix='test.php' $@
   else
     run_cmd vendor/bin/phpunit --configuration='phpunit.xml' --test-suffix='test.php' $@
   fi
 }
+alias unit='phpunit'
 
 # Get the number of threads that is set to be used from the config.php
 behat_parallel_count() {
@@ -141,21 +154,21 @@ behat_parallel_count() {
         echo(0);
     }
   "
-  echo `php -r "$php_code"`
+  php -r "$php_code"
 }
 
 # Initialise Behat
-installbehat() {
+install_behat() {
   site_root || return 1
 
   # Make sure this is a supported Totara version
-  if [[ $(echo "`totara_version` <= 2.5" | bc -l) == '1' ]]; then
+  if [[ $(echo "$(totara_version major) <= 2.5" | bc -l) == '1' ]]; then
     print_error "This script doesn't currently support Totara 2.5 or earlier."
     print_info "If you know how to make it work, please contribute a solution."
     return 1
   fi
 
-  local parallel_count=`behat_parallel_count`
+  local parallel_count=$(behat_parallel_count)
   if [[ $parallel_count != '0' || "$*" =~ "--parallel" ]]; then
     print_info "Initialising behat in parallel mode"
   else
@@ -167,36 +180,31 @@ installbehat() {
     run_totara_cmd php admin/tool/behat/cli/init.php --parallel=$parallel_count $@
   fi
 }
+alias installbehat='install_behat'
 
 # Run Behat
 behat() {
   site_root || return 1
 
   # Make sure this is a supported Totara version
-  if [[ $(echo "`totara_version` <= 2.5" | bc -l) == '1' ]]; then
+  if [[ $(echo "$(totara_version major) <= 2.5" | bc -l) == '1' ]]; then
     print_error "This script doesn't currently support Totara 2.5 or earlier."
     print_info "If you know how to make it work, please contribute a solution."
     return 1
   fi
 
   # Behat.yml variables
-  local behat_dataroot_php="
-    define(\"CLI_SCRIPT\", true);
-    define(\"ABORT_AFTER_CONFIG\", true);
-    require(\"config.php\");
-    echo \$CFG->behat_dataroot;
-  "
-  local behat_dataroot=`php -r "$behat_dataroot_php"`
+  local behat_dataroot=$(config_var behat_dataroot)
   local behat_dataroot_yml="$behat_dataroot/behat/behat.yml"
   local behat_source_yml="./behat.yml"
-  if [ -f './server/version.php' ]; then
+  if [[ -f './server/version.php' ]]; then
     behat_dataroot_yml="$behat_dataroot/behatrun/behat/behat.yml"
     behat_source_yml="./behat_local.yml"
   fi
 
   # Parallel mode variables
   local parallel_mode="0"
-  local parallel_count=`behat_parallel_count`
+  local parallel_count=$(behat_parallel_count)
   local selenium_host="selenium-chrome-debug"
   if [[ $parallel_count != '0' || "$*" =~ "--parallel" ]]; then
     selenium_host="selenium-hub"
@@ -213,7 +221,7 @@ behat() {
   # Abort if the appropriate selenium container isn't running
   if ! nc -w5 -z -v $selenium_host 4444 &> /dev/null; then
     print_error "The $selenium_host container must be running in order to run behat tests"
-    [ $parallel_mode == '1' ] && print_error "(Also don't forget to create multiple selenium-chrome instances!)"
+    [[ $parallel_mode == '1' ]] && print_error "(Also don't forget to create multiple selenium-chrome instances!)"
     return 1
   fi
 
@@ -240,7 +248,7 @@ behat() {
   done
 
   # Run the actual command
-  if [ $parallel_mode == '1' ]; then
+  if [[ $parallel_mode == '1' ]]; then
     print_info "Running behat in parallel mode"
     if [[ ! "$*" =~ "--parallel" ]]; then
       run_totara_cmd php admin/tool/behat/cli/run.php "${args[@]}"
@@ -249,7 +257,7 @@ behat() {
     fi
   else
     print_info "Running behat in single (debug) mode"
-    if [ -f './server/version.php' ]; then
+    if [[ -f './server/version.php' ]]; then
       run_cmd test/behat/vendor/bin/behat --config "$behat_dataroot_yml" "${args[@]}"
     else
       run_cmd vendor/bin/behat --config "$behat_dataroot_yml" "${args[@]}"
@@ -258,11 +266,13 @@ behat() {
 }
 
 # Create a test course
-createcourse() {
+create_course() {
   run_totara_cmd php admin/tool/generator/cli/maketestcourse.php --shortname=course --size=S $@
 }
+alias createcourse='create_course'
 
 # Create a test user
-createuser() {
+create_user() {
   run_totara_cmd php totara/generator/cli/maketestuser.php $@
 }
+alias createuser='create_user'


### PR DESCRIPTION
This allows you to specify `--processes=N` or `--parallel=N` for the `installunit` and `unit` phpunit aliases that we have.

I also took the opportunity to tidy up the existing bash code for our alias functions and split them out into more isolated functions so its easier to reuse stuff in the future.