### PR TITLE
Fix mutagen 12 compatibility and start correct containers

### DIFF
--- a/bin/tup
+++ b/bin/tup
@@ -31,7 +31,7 @@ for container in "${containers[@]}"; do
 done
 
 # Always start up the sync container for mutagen
-if [ -f "$project_path/.use-mutagen" ]; then
+if [[ "$USE_MUTAGEN" == "1" || -f "$project_path/.use-mutagen" ]]; then
     containers_to_start+=("sync")
 fi
 
@@ -40,7 +40,7 @@ $script_path/tdocker up -d "${containers_to_start[@]}"
 # if mutagen should be used make sure it's started
 if [[ "$USE_MUTAGEN" == "1" || -f "$project_path/.use-mutagen" ]]; then
     # check if there's already a session
-    mutagen list | grep "$REMOTE_SRC" &> /dev/null
+    mutagen sync list | grep "$REMOTE_SRC" &> /dev/null
 
     if [ $? != 0 ]; then
         mutagen sync create \


### PR DESCRIPTION
Mutagen 12 removed the ability to use the commands without the "sync" argument. It was still used in one place.

Additionally the USE_MUTAGEN configuration option was not checked in all relevant places resulting in the sync container not being started.