### PR TITLE
Use compatible postgres version as default

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -8,7 +8,7 @@ LOCAL_SRC=/your/totara/src/path
 # Like most CMSes, Totara requires a webserver, a database, and PHP
 # It is recommended to use nginx, and the latest version of postgres and PHP for better performance
 # Note that specifying just 'php' will automatically use the latest version of PHP that the Totara site supports
-DEFAULT_CONTAINERS=nginx,pgsql14,php
+DEFAULT_CONTAINERS=nginx,pgsql13,php
 
 # set this to your local IP address
 # for mac just use "host.docker.internal"


### PR DESCRIPTION
Postgres 14 is not officially supported by Totara yet but was already added as the default Postgres container to start.