### PR TITLE
Added in the ml-service image for Machine Learning

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -27,6 +27,14 @@ NGROK_REGION=au
 # Build settings (this will have an affect on build only)
 TIME_ZONE=Pacific/Auckland
 
+# Machine Learning (T15+)
+# Set this to the root of the Totara project you want to run
+# machine learning on. If you run multiple instances then it must point
+# to a single instance. This is *not* the /server directory, but the one above.
+# ML_TOTARA_PROJECT=/your/totara/src/project
+# Point to the web root of your Totara project you are connecting the ML service to.
+# ML_TOTARA_URL=http://totara73/my-project/server
+
 # Defaults - you shouldn't really need to change these.
 REMOTE_SRC=/var/www/totara/src
 REMOTE_DATA=/var/www/totara/data

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Although this project started as a development environment for Totara Learn it c
  * [Redis](https://redis.io/) for caching and/or session handling
  * [XHProf](https://github.com/tideways/php-xhprof-extension) for profiling
  * [XDebug](https://xdebug.org/) installed, ready for debugging with your favorite IDE
+ * A [Python](https://www.python.org/) instance to run the Totara Machine Learning service
 
 ## Installation & Usage
 

--- a/bin/tdocker
+++ b/bin/tdocker
@@ -18,6 +18,7 @@ files=(
     "compose/pgsql.yml"
     "compose/php.yml"
     "compose/selenium.yml"
+    "compose/machine-learning.yml"
 )
 
 if [ "$1" ==  "build" ]; then

--- a/compose/machine-learning.yml
+++ b/compose/machine-learning.yml
@@ -1,0 +1,24 @@
+version: "3.7"
+services:
+  ml-service:
+    build:
+      context: ${ML_TOTARA_PROJECT:?Set the path to your Totara project}/extensions/ml_service
+      target: mlbase
+    init: true
+    pull_policy: build
+    environment:
+      ML_TOTARA_KEY: ${ML_API_KEY:-totara}
+      ML_TOTARA_URL: ${ML_TOTARA_URL:?Set the URL of your Totara project}
+      ML_DEV: 1
+    volumes:
+      - "${ML_TOTARA_PROJECT}/extensions/ml_service/service:/etc/ml/service"
+      - "ml-models:/etc/ml/data/models"
+      - "ml-logs:/etc/ml/data/train_logs"
+    networks:
+      - totara
+    ports:
+      - "5000:5000"
+
+volumes:
+  ml-models:
+  ml-logs:


### PR DESCRIPTION
I've got the basic docker-compose image in. Because Machine Learning is targeted at a single Totara instance, we can't make it a single container that can run all sites at once, but it can be configured via the `.env` file to target a single Totara instance.

The Docker image also belongs to Totara, not Totara Docker, and it ties to a specific release, so if changing versions you'll have to rebuild the image again. Could potentially extend it with a custom /bin script to running multiple at once, but I think this is a good first step.


This version is only for the T15+ ml_service, the older ml_recommender is still a TODO.


To try it out:
1. Edit your Totara config and add the following:
  `$CFG->ml_service_url = 'http://ml-service:5000';`
  `$CFG->ml_service_key = 'totara';`
2. Edit the `.env` file and add the following:
  `ML_TOTARA_PROJECT=/path/to/totara/root` - This needs to point at the base (not /server) of one Totara project
  `ML_TOTARA_URL=http://totara73/project/server`
3. Run `tup ml-service` or `tdocker up ml-service`
4. Check you can access `http://localhost:5000` and you see the ML service homepage
5. Connect to your PHP container, and then run `php server/ml/service/cli/healthcheck.php` from the Totara project root. This will confirm if the two-way connection is running successfully.