### PR TITLE
Increase max_input_vars to support Totara 17

### DIFF
--- a/php/php74/config/php.ini
+++ b/php/php74/config/php.ini
@@ -8,3 +8,5 @@ memory_limit=256M
 max_execution_time=120
 post_max_size = 64M
 upload_max_filesize = 64M
+; T17 and later require max_input_vars to be set to at least 5000
+max_input_vars=5000

--- a/php/php80/config/php.ini
+++ b/php/php80/config/php.ini
@@ -8,6 +8,8 @@ memory_limit=256M
 max_execution_time=120
 post_max_size = 64M
 upload_max_filesize = 64M
+; T17 and later require max_input_vars to be set to at least 5000
+max_input_vars=5000
 
 # Turn on the OPcache for command-line PHP
 opcache.enable_cli=1

--- a/php/php81/config/php.ini
+++ b/php/php81/config/php.ini
@@ -8,3 +8,5 @@ memory_limit=256M
 max_execution_time=120
 post_max_size = 64M
 upload_max_filesize = 64M
+; T17 and later require max_input_vars to be set to at least 5000
+max_input_vars=5000


### PR DESCRIPTION
Following the hotfix process in https://github.com/totara/totara-docker-dev/blob/master/CONTRIBUTING.md#hotfixes

Those 3 containers will also need rebuilding and pushing.