### PR TITLE
Upgrade Node.js to v16

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
   # docker-compose -f docker-compose.yml -f compose/nginx.yml -f compose/pgsql.yml -f compose/php.yml up -d pgsql php-7.3
 
   nodejs:
-    image: node:12
+    image: node:16
     container_name: totara_nodejs
     environment:
       TZ: ${TIME_ZONE}


### PR DESCRIPTION
Update the Node.js image to point to v16 LTS.

v12 support is being dropped in T17, and v18 support is not yet in released versions.