### PR TITLE
Fixing machine learning so it's only included if it has been configured

### DIFF
--- a/bin/tdocker
+++ b/bin/tdocker
@@ -18,8 +18,13 @@ files=(
     "compose/pgsql.yml"
     "compose/php.yml"
     "compose/selenium.yml"
-    "compose/machine-learning.yml"
 )
+
+if [[ ! -z "${ML_TOTARA_PROJECT}" ]]; then
+    files+=(
+        "compose/machine-learning.yml"
+    )
+fi
 
 if [ "$1" ==  "build" ]; then
     files+=(


### PR DESCRIPTION
The ML compose file is a bit too aggressive, and demands configuration when you aren't using ML. This limits it to only being included if you've uncommented the ML variables in the .env file.