### PR TITLE
Expose ML_* environment options to the .env file

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -34,6 +34,14 @@ TIME_ZONE=Pacific/Auckland
 # ML_TOTARA_PROJECT=/your/totara/src/project
 # Point to the web root of your Totara project you are connecting the ML service to.
 # ML_TOTARA_URL=http://totara73/my-project/server
+# Whether to run in dev mode or production mode. 1 = dev, 0 = prod. Defaults to 1.
+# ML_DEV=1
+#
+# Optional Machine Learning settings.
+# These are all documented in totara/extensions/ml_service/readme.md
+# ML_RECOMMENDATION_RETRAIN_FREQ=1440
+# ML_NUM_THREADS=4
+# ML_RECOMMENDATION_ALGORITHM=hybrid
 
 # Defaults - you shouldn't really need to change these.
 REMOTE_SRC=/var/www/totara/src

--- a/compose/machine-learning.yml
+++ b/compose/machine-learning.yml
@@ -9,7 +9,11 @@ services:
     environment:
       ML_TOTARA_KEY: ${ML_API_KEY:-totara}
       ML_TOTARA_URL: ${ML_TOTARA_URL:?Set the URL of your Totara project}
-      ML_DEV: 1
+      ML_RECOMMENDATION_RETRAIN_FREQ: ${ML_RECOMMENDATION_RETRAIN_FREQ:-1440}
+      ML_NUM_THREADS: ${ML_NUM_THREADS:-4}
+      ML_RECOMMENDATION_ALGORITHM: ${ML_RECOMMENDATION_ALGORITHM:-hybrid}
+      ML_DEV: ${ML_DEV:-1}
+      PYTHONUNBUFFERED: ${ML_DEV:-1}
     volumes:
       - "${ML_TOTARA_PROJECT}/extensions/ml_service/service:/etc/ml/service"
       - "ml-models:/etc/ml/data/models"
@@ -17,7 +21,7 @@ services:
     networks:
       - totara
     ports:
-      - "5000:5000"
+      - "5050:5000"
 
 volumes:
   ml-models:


### PR DESCRIPTION
Fixes #228 

+ Added the ML_* environment options so they can be changed in .env
+ Changed the external port to 5050 so it no longer clashes with Mac (this is only used for a dev who wants to look at the service directly, internally it still uses 5000)