### PR TITLE
Add tphp command

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -24,6 +24,9 @@ HOST_IP=host.docker.internal
 # Available ngrok regions: us (Ohio), eu (Frankfurt), ap (Singapore), au (Sydney), sa (Sao Paulo), jp (Tokyo), in (Mumbai)
 NGROK_REGION=au
 
+# Set your preferred shell (used by things like tphp). bash and zsh are available.
+INTERACTIVE_SHELL=zsh
+
 # Build settings (this will have an affect on build only)
 TIME_ZONE=Pacific/Auckland
 

--- a/bin/tbash
+++ b/bin/tbash
@@ -1,11 +1,6 @@
 #!/bin/bash
 
-# Standard boilerplate code for getting the paths and environment variables we need.
 script_path="$( cd "$(dirname "$0")" ; pwd -P )"
-project_path="$( cd $script_path && cd ..; pwd -P )"
-export $(grep -E -v '^#' $project_path/.env | xargs)
-sub_path="${PWD//$LOCAL_SRC/}"
-remote_path="$REMOTE_SRC/$sub_path"
 
 if [ ! -f "$local_path/version.php" ]; then
     remote_path="$REMOTE_SRC"
@@ -17,21 +12,4 @@ if [[ -z "$container" ]]; then
     container="php"
 fi
 
-# If just 'php' is specified, then dynamically work out which one to actually use based upon the site composer.json
-if [[ "$container" == "php" ]]; then
-    if [[ ! -f "$local_path/version.php" ]]; then
-        echo "This command must be run from a Totara site directory if 'php' is specified for the container"
-        exit 1
-    fi
-    php_container=($(php "$project_path/bin/helpers/php_container.php" "$local_path"))
-    container=${php_container[0]}
-    echo -e "\x1B[2mUsing PHP Container: $container\x1B[0m"
-fi
-
-# If we are bashing into php/apache/nginx, then lets make the shell begin in the remote directory
-extra_args=""
-if [[ "$container" =~ "php" || "$container" =~ "nginx" || "$container" =~ "apache" ]]; then
-    extra_args="-w $remote_path"
-fi
-
-$script_path/tdocker exec $extra_args "$container" /bin/bash
+$script_path/texec "$container" /bin/bash

--- a/bin/texec
+++ b/bin/texec
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Standard boilerplate code for getting the paths and environment variables we need.
+script_path="$( cd "$(dirname "$0")" ; pwd -P )"
+project_path="$( cd $script_path && cd ..; pwd -P )"
+export $(grep -E -v '^#' $project_path/.env | xargs)
+sub_path="${PWD//$LOCAL_SRC/}"
+remote_path="$REMOTE_SRC/$sub_path"
+local_path="$LOCAL_SRC/$sub_path"
+
+container="$1"
+shift
+if [[ -z "$container" ]]; then
+    echo "Container must be specified"
+    exit 1
+fi
+
+# If just 'php' is specified, then dynamically work out which one to actually use based upon the site composer.json
+if [[ "$container" == "php" ]]; then
+    if [[ ! -f "$local_path/version.php" ]]; then
+        echo "This command must be run from a Totara site directory if 'php' is specified for the container"
+        exit 1
+    fi
+    php_container=($(php "$project_path/bin/helpers/php_container.php" "$local_path"))
+    container=${php_container[0]}
+    echo -e "\x1B[2mUsing PHP Container: $container\x1B[0m"
+fi
+
+# If we are bashing into php/apache/nginx, then lets make the shell begin in the remote directory
+extra_args=""
+if [[ "$container" =~ "php" || "$container" =~ "nginx" || "$container" =~ "apache" ]]; then
+    extra_args="-w $remote_path"
+fi
+
+# Quote command to be reused as shell input
+command_str=$(printf " %q" "$@")
+
+$script_path/tdocker exec $extra_args "$container" "$command_str"
+

--- a/bin/tphp
+++ b/bin/tphp
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Standard boilerplate code for getting the paths and environment variables we need.
+script_path="$( cd "$(dirname "$0")" ; pwd -P )"
+project_path="$( cd $script_path && cd ..; pwd -P )"
+export $(grep -E -v '^#' $project_path/.env | xargs)
+
+if [[ -z "$1" ]]; then
+    $script_path/texec php "${INTERACTIVE_SHELL:-zsh}"
+else
+    # Quote command to be reused as shell input
+    command_str=$(printf " %q" "$@")
+    # Handle being called with a php script instead of a command
+    if [[ $1 == *.php ]]; then
+        command_str="php $command_str"
+    fi
+    $script_path/texec php bash -ic "$command_str"
+fi

--- a/bin/tzsh
+++ b/bin/tzsh
@@ -1,31 +1,16 @@
 #!/bin/bash
 
-# Standard boilerplate code for getting the paths and environment variables we need.
 script_path="$( cd "$(dirname "$0")" ; pwd -P )"
-project_path="$( cd $script_path && cd ..; pwd -P )"
-export $(grep -E -v '^#' $project_path/.env | xargs)
-sub_path="${PWD//$LOCAL_SRC/}"
-remote_path="$REMOTE_SRC/$sub_path"
-local_path="$LOCAL_SRC/$sub_path"
 
-if [ ! -f "$local_path/version.php" ]; then
-    remote_path="$REMOTE_SRC"
+# If the container isn't specified, then we just default to the default php container.
+container="$1"
+if [[ -z "$container" ]]; then
+    container="php"
 fi
 
-container="$1"
 if [[ ! "$container" =~ "php" ]]; then
     echo "tzsh only supports php containers"
     exit 1
 fi
 
-# If just 'php' is specified, then dynamically work out which one to actually use based upon the site composer.json
-if [[ "$container" == "php" ]]; then
-    if [[ ! -f "$local_path/version.php" ]]; then
-        echo "This command must be run from a Totara site directory if 'php' is specified for the container"
-        exit 1
-    fi
-    php_container=($(php "$project_path/bin/helpers/php_container.php" "$local_path"))
-    container=${php_container[0]}
-fi
-
-$script_path/tdocker exec -w $remote_path "$container" /bin/zsh
+$script_path/texec "$container" /bin/zsh


### PR DESCRIPTION
This PR adds a tphp command for executing commands inside the php container.

Example:

```
sc ~/c/t/learn> tdb drop
Successfully dropped pgsql14 database learn_17
sc ~/c/t/learn> tdb create
Successfully created pgsql14 database learn_17
sc ~/c/t/learn> tphp install
Using PHP Container: php-8.1
Running Command: php server/admin/cli/install_database.php --adminpass=admin --adminemail=admin@example.com --agree-license --shortname=Totara 17 development site --fullname=Totara 17 development site
Totara 17.0+ (Build: 20221108.00) command line installation program
-------------------------------------------------------------------------------
== Setting up database ==
-->System
++ Success ++
-->totara_core
++ Success ++
```

This makes it a bit more convenient to use the install/cron/purge/etc aliases without needing to tbash in to the container.