### PR TITLE
232 Allow servers access to checknet.txt

### DIFF
--- a/apache/config/remote-server.conf
+++ b/apache/config/remote-server.conf
@@ -5,6 +5,7 @@
 LimitRequestBody 10485760
 
 # Don't allow the following files/directories to be accessed
+RewriteCond %{REQUEST_URI} !^/checknet.txt$
 RewriteRule (\/cli\/|\/tests\/|\/db\/|\/lang\/|\/classes\/|\/amd\/src\/|/rb_sources/|\/yui\/src\/|\/templates\/) - [R=404]
 RewriteRule \.(txt|md|json|xml|mustache) - [R=404]
 RewriteRule \/\. - [R=404]

--- a/nginx/config/remote-server.conf
+++ b/nginx/config/remote-server.conf
@@ -63,4 +63,5 @@ location ~ /\. {
 
 location ~ .*\.(txt|md|json|xml|mustache)$ {
     deny all;
+    allow checknet.txt;
 }


### PR DESCRIPTION
Fixing for this issue https://github.com/totara/totara-docker-dev/issues/232