### PR TITLE
Base image

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -1,6 +1,6 @@
-FROM httpd:2.4
+FROM httpd:2.4-alpine
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+RUN apk update && apk add \
     nano \
     openssl \
     gettext

--- a/apache/entrypoint.sh
+++ b/apache/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # if there's no ssl certificate yet create it
 if [ ! -f "/usr/local/apache2/conf/server.crt" ]; then

--- a/compose/pgsql.yml
+++ b/compose/pgsql.yml
@@ -2,7 +2,7 @@ version: "3.7"
 services:
 
   pgsql93:
-    image: postgres:9.3
+    image: postgres:9.3-alpine
     container_name: totara_pgsql93
     ports:
       - "5493:5432"
@@ -20,7 +20,7 @@ services:
       - totara
 
   pgsql96:
-    image: postgres:9.6
+    image: postgres:9.6-alpine
     container_name: totara_pgsql96
     ports:
       - "5496:5432"
@@ -39,13 +39,14 @@ services:
       - totara
 
   pgsql10:
-    image: postgres:10.6
+    image: postgres:10-alpine
     container_name: totara_pgsql10
     ports:
       - "5410:5432"
     environment:
       TZ: ${TIME_ZONE}
       PGDATA: /var/lib/postgresql/data/pgdata
+      POSTGRES_HOST_AUTH_METHOD: trust
     command:
       postgres -c 'config_file=/etc/postgresql/postgresql.conf'
     volumes:
@@ -57,13 +58,14 @@ services:
       - totara
 
   pgsql11:
-    image: postgres:11.6
+    image: postgres:11-alpine
     container_name: totara_pgsql11
     ports:
       - "5411:5432"
     environment:
       TZ: ${TIME_ZONE}
       PGDATA: /var/lib/postgresql/data/pgdata
+      POSTGRES_HOST_AUTH_METHOD: trust
     command:
       postgres -c 'config_file=/etc/postgresql/postgresql.conf'
     volumes:
@@ -75,13 +77,14 @@ services:
       - totara
 
   pgsql:
-    image: postgres:12.1
+    image: postgres:12-alpine
     container_name: totara_pgsql12
     ports:
       - "5432:5432"
     environment:
       TZ: ${TIME_ZONE}
       PGDATA: /var/lib/postgresql/data/pgdata
+      POSTGRES_HOST_AUTH_METHOD: trust
     command:
       postgres -c 'config_file=/etc/postgresql/postgresql.conf'
     volumes:
@@ -93,7 +96,7 @@ services:
       - totara
 
   pgsql13:
-    image: postgres:13.0
+    image: postgres:13-alpine
     container_name: totara_pgsql13
     ports:
       - "5442:5432"
@@ -112,7 +115,7 @@ services:
       - totara
 
   pgsql14:
-    image: postgres:14.0
+    image: postgres:14-alpine
     container_name: totara_pgsql14
     ports:
       - "5443:5432"

--- a/config.php
+++ b/config.php
@@ -466,6 +466,7 @@ $CFG->smtphosts = 'mailcatcher:25';
 
 $CFG->passwordpolicy = false;
 $CFG->tool_generator_users_password = '12345';
+$CFG->upgradekey = '';
 
 $CFG->country = 'NZ';
 $CFG->defaultcity = 'Wellington'; // very windy!

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
   # docker-compose -f docker-compose.yml -f compose/nginx.yml -f compose/pgsql.yml -f compose/php.yml up -d pgsql php-7.3
 
   nodejs:
-    image: node:16
+    image: node:16-alpine3.16
     container_name: totara_nodejs
     environment:
       TZ: ${TIME_ZONE}
@@ -28,7 +28,8 @@ services:
       - totara
 
   redis:
-    image: redis
+    image: redis:alpine
+    container_name: totara_redis
     # activate persistency
     command: "redis-server --appendonly yes"
     environment:
@@ -39,7 +40,8 @@ services:
       - totara
 
   memcached:
-    image: memcached
+    image: memcached:alpine
+    container_name: totara_memcached
     environment:
       TZ: ${TIME_ZONE}
     networks:

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,8 +1,8 @@
-FROM nginx:1.20
+FROM nginx:alpine
 
 ENV REMOTE_DATA=${REMOTE_DATA}
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+RUN apk update && apk add \
     nano \
     openssl \
     gettext

--- a/nginx/entrypoint.sh
+++ b/nginx/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # if there's no ssl certificate yet create it
 if [ ! -f "/etc/nginx/ssl/domain.crt" ]


### PR DESCRIPTION
I replced the base image of apache, nginx, postgresql, nodejs, redis and memcache to alpine linux. I also add mariadb10.9 and postgresql 15 to the list.
The reason for replacement were that alpine linux is smaller and consume less resource and less vulnerability.
I will replace those php image in next commit.