### PR TITLE
Replace base image to alpine

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -1,6 +1,6 @@
-FROM httpd:2.4
+FROM httpd:2.4-alpine
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+RUN apk update && apk add \
     nano \
     openssl \
     gettext

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -1,4 +1,5 @@
-FROM httpd:2.4-alpine
+ARG ARCH=amd64
+FROM $ARCH/httpd:2.4-alpine
 
 RUN apk update && apk add \
     nano \

--- a/apache/entrypoint.sh
+++ b/apache/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # if there's no ssl certificate yet create it
 if [ ! -f "/usr/local/apache2/conf/server.crt" ]; then

--- a/bin/tbuild
+++ b/bin/tbuild
@@ -2,5 +2,11 @@
 
 script_path="$( cd "$(dirname "$0")" ; pwd -P )"
 project_path="$( cd $script_path && cd ..; pwd -P )"
+export $(grep -E -v '^#' $project_path/.env | xargs)
 
-$script_path/tdocker build "$@"
+# Check the OS and make image for that OS
+if [ $(uname -m) == "arm64" ]; then
+  $script_path/tdocker build --build-arg ARCH="arm64v8" "$@"
+else
+  $script_path/tdocker build "$@"
+fi

--- a/compose/pgsql.yml
+++ b/compose/pgsql.yml
@@ -2,7 +2,7 @@ version: "3.7"
 services:
 
   pgsql93:
-    image: postgres:9.3
+    image: postgres:9.3-alpine
     container_name: totara_pgsql93
     ports:
       - "5493:5432"
@@ -20,7 +20,7 @@ services:
       - totara
 
   pgsql96:
-    image: postgres:9.6
+    image: postgres:9.6-alpine
     container_name: totara_pgsql96
     ports:
       - "5496:5432"
@@ -39,13 +39,14 @@ services:
       - totara
 
   pgsql10:
-    image: postgres:10.6
+    image: postgres:10-alpine
     container_name: totara_pgsql10
     ports:
       - "5410:5432"
     environment:
       TZ: ${TIME_ZONE}
       PGDATA: /var/lib/postgresql/data/pgdata
+      POSTGRES_HOST_AUTH_METHOD: trust
     command:
       postgres -c 'config_file=/etc/postgresql/postgresql.conf'
     volumes:
@@ -57,13 +58,14 @@ services:
       - totara
 
   pgsql11:
-    image: postgres:11.6
+    image: postgres:11-alpine
     container_name: totara_pgsql11
     ports:
       - "5411:5432"
     environment:
       TZ: ${TIME_ZONE}
       PGDATA: /var/lib/postgresql/data/pgdata
+      POSTGRES_HOST_AUTH_METHOD: trust
     command:
       postgres -c 'config_file=/etc/postgresql/postgresql.conf'
     volumes:
@@ -75,13 +77,14 @@ services:
       - totara
 
   pgsql:
-    image: postgres:12.1
+    image: postgres:12-alpine
     container_name: totara_pgsql12
     ports:
       - "5432:5432"
     environment:
       TZ: ${TIME_ZONE}
       PGDATA: /var/lib/postgresql/data/pgdata
+      POSTGRES_HOST_AUTH_METHOD: trust
     command:
       postgres -c 'config_file=/etc/postgresql/postgresql.conf'
     volumes:
@@ -93,7 +96,7 @@ services:
       - totara
 
   pgsql13:
-    image: postgres:13.0
+    image: postgres:13-alpine
     container_name: totara_pgsql13
     ports:
       - "5442:5432"
@@ -112,7 +115,7 @@ services:
       - totara
 
   pgsql14:
-    image: postgres:14.0
+    image: postgres:14-alpine
     container_name: totara_pgsql14
     ports:
       - "5443:5432"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
   # docker-compose -f docker-compose.yml -f compose/nginx.yml -f compose/pgsql.yml -f compose/php.yml up -d pgsql php-7.3
 
   nodejs:
-    image: node:16
+    image: node:16-alpine3.16
     container_name: totara_nodejs
     environment:
       TZ: ${TIME_ZONE}
@@ -28,7 +28,8 @@ services:
       - totara
 
   redis:
-    image: redis
+    image: redis:alpine
+    container_name: totara_redis
     # activate persistency
     command: "redis-server --appendonly yes"
     environment:
@@ -39,7 +40,8 @@ services:
       - totara
 
   memcached:
-    image: memcached
+    image: memcached:alpine
+    container_name: totara_memcached
     environment:
       TZ: ${TIME_ZONE}
     networks:

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,8 +1,8 @@
-FROM nginx:1.20
+FROM nginx:alpine
 
 ENV REMOTE_DATA=${REMOTE_DATA}
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+RUN apk update && apk add \
     nano \
     openssl \
     gettext

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,5 @@
-FROM nginx:alpine
+ARG ARCH=amd64
+FROM $ARCH/nginx:alpine
 
 ENV REMOTE_DATA=${REMOTE_DATA}
 

--- a/nginx/entrypoint.sh
+++ b/nginx/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # if there's no ssl certificate yet create it
 if [ ! -f "/etc/nginx/ssl/domain.crt" ]

--- a/php/php71/Dockerfile
+++ b/php/php71/Dockerfile
@@ -1,4 +1,5 @@
-FROM php:7.1-fpm-stretch
+ARG ARCH=amd64
+FROM $ARCH/php:7.1-fpm-buster
 
 ARG TIME_ZONE=Pacific/Auckland
 
@@ -80,20 +81,20 @@ ENV LC_ALL en_US.UTF-8
 
 # install mssql extension
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
-    && curl https://packages.microsoft.com/config/debian/8/prod.list | tee /etc/apt/sources.list.d/mssql-tools.list \
+    && curl https://packages.microsoft.com/config/debian/11/prod.list | tee /etc/apt/sources.list.d/mssql-tools.list \
     && apt-get update && ACCEPT_EULA=Y apt-get install -y \
-        msodbcsql17 \
-        mssql-tools \
+        msodbcsql18 \
+        mssql-tools18 \
         unixodbc-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Workaround to get MSSQL connection working on Debian 9 (stretch)
 # https://emacstragic.net/2017/11/06/mssql-odbc-client-on-debian-9-stretch/
-RUN wget "http://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u12_amd64.deb" \
-    && DEBIAN_FRONTEND=noninteractive dpkg -i ./libssl1.0.0_1.0.1t-1+deb8u12_amd64.deb
+#RUN wget "http://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u12_amd64.deb" \
+#    && DEBIAN_FRONTEND=noninteractive dpkg -i ./libssl1.0.0_1.0.1t-1+deb8u12_amd64.deb
 
-RUN echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bash_profile \
-    && echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc
+RUN echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bash_profile \
+    && echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bashrc
 
 RUN pear config-set php_ini `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"` system \
     && pecl install sqlsrv-5.6.1 \

--- a/php/php72/Dockerfile
+++ b/php/php72/Dockerfile
@@ -1,4 +1,5 @@
-FROM php:7.2-fpm
+ARG ARCH=amd64
+FROM $ARCH/php:7.2-fpm
 
 ARG TIME_ZONE=Pacific/Auckland
 
@@ -30,7 +31,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         graphviz \
         aspell \
         libldap2-dev \
-    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
     && docker-php-ext-install -j$(nproc) xmlrpc \
         zip \
         intl \
@@ -83,20 +83,20 @@ ENV LC_ALL en_US.UTF-8
 
 # install mssql extension
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
-    && curl https://packages.microsoft.com/config/debian/8/prod.list | tee /etc/apt/sources.list.d/mssql-tools.list \
+    && curl https://packages.microsoft.com/config/debian/11/prod.list | tee /etc/apt/sources.list.d/mssql-tools.list \
     && apt-get update && ACCEPT_EULA=Y apt-get install -y \
-        msodbcsql17 \
-        mssql-tools \
+        msodbcsql18 \
+        mssql-tools18 \
         unixodbc-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Workaround to get MSSQL connection working on Debian 9 (stretch)
 # https://emacstragic.net/2017/11/06/mssql-odbc-client-on-debian-9-stretch/
-RUN wget "http://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u12_amd64.deb" \
-    && DEBIAN_FRONTEND=noninteractive dpkg -i ./libssl1.0.0_1.0.1t-1+deb8u12_amd64.deb
+#RUN wget "http://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u12_amd64.deb" \
+#    && DEBIAN_FRONTEND=noninteractive dpkg -i ./libssl1.0.0_1.0.1t-1+deb8u12_amd64.deb
 
-RUN echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bash_profile \
-    && echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc
+RUN echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bash_profile \
+    && echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bashrc
 
 RUN pear config-set php_ini `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"` system \
     && pecl install sqlsrv-5.8.1 \

--- a/php/php73/Dockerfile
+++ b/php/php73/Dockerfile
@@ -1,4 +1,5 @@
-FROM php:7.3-fpm-buster
+ARG ARCH=amd64
+FROM $ARCH/php:7.3-fpm-buster
 
 ARG TIME_ZONE=Pacific/Auckland
 
@@ -30,7 +31,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         graphviz \
         aspell \
         libldap2-dev \
-    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
     && docker-php-ext-install -j$(nproc) xmlrpc \
         zip \
         intl \
@@ -83,20 +83,20 @@ ENV LC_ALL en_US.UTF-8
 
 # install mssql extension
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
-    && curl https://packages.microsoft.com/config/debian/10/prod.list > /etc/apt/sources.list.d/mssql-release.list \
+    && curl https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list \
     && apt-get update && ACCEPT_EULA=Y apt-get install -y \
-        msodbcsql17 \
-        mssql-tools \
+        msodbcsql18 \
+        mssql-tools18 \
         unixodbc-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Workaround to get MSSQL connection working on Debian 9 (stretch)
 # https://emacstragic.net/2017/11/06/mssql-odbc-client-on-debian-9-stretch/
-RUN wget "http://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u12_amd64.deb" \
-    && DEBIAN_FRONTEND=noninteractive dpkg -i ./libssl1.0.0_1.0.1t-1+deb8u12_amd64.deb
+#RUN wget "http://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u12_amd64.deb" \
+#    && DEBIAN_FRONTEND=noninteractive dpkg -i ./libssl1.0.0_1.0.1t-1+deb8u12_amd64.deb
 
-RUN echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bash_profile \
-    && echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc
+RUN echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bash_profile \
+    && echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bashrc
 
 RUN pear config-set php_ini `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"` system \
     && pecl install sqlsrv-5.9.0 \

--- a/php/php74/Dockerfile
+++ b/php/php74/Dockerfile
@@ -1,4 +1,5 @@
-FROM php:7.4-fpm-buster
+ARG ARCH=amd64
+FROM $ARCH/php:7.4-fpm-buster
 
 ARG TIME_ZONE=Pacific/Auckland
 
@@ -28,7 +29,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         graphviz \
         aspell \
         libldap2-dev \
-    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
     && docker-php-ext-install -j$(nproc) xmlrpc \
         zip \
         intl \
@@ -78,19 +78,19 @@ ENV LC_ALL en_US.UTF-8
 
 # install mssql extension
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
-    && curl https://packages.microsoft.com/config/debian/10/prod.list > /etc/apt/sources.list.d/mssql-release.list \
+    && curl https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list \
     && apt-get update && ACCEPT_EULA=Y apt-get install -y \
-    msodbcsql17 \
-    mssql-tools \
+    msodbcsql18 \
+    mssql-tools18 \
     unixodbc-dev
 
 # Workaround to get MSSQL connection working on Debian 9 (stretch)
 # https://emacstragic.net/2017/11/06/mssql-odbc-client-on-debian-9-stretch/
-RUN wget "http://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u12_amd64.deb" \
-    && DEBIAN_FRONTEND=noninteractive dpkg -i ./libssl1.0.0_1.0.1t-1+deb8u12_amd64.deb
+#RUN wget "http://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u12_amd64.deb" \
+#    && DEBIAN_FRONTEND=noninteractive dpkg -i ./libssl1.0.0_1.0.1t-1+deb8u12_amd64.deb
 
-RUN echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bash_profile \
-    && echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc
+RUN echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bash_profile \
+    && echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bashrc
 
 RUN pear config-set php_ini `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"` system \
     && pecl install sqlsrv-5.10.0 \

--- a/php/php80/Dockerfile
+++ b/php/php80/Dockerfile
@@ -1,4 +1,5 @@
-FROM php:8.0-fpm-buster
+ARG ARCH=amd64
+FROM $ARCH/php:8.0-fpm-buster
 
 ARG TIME_ZONE=Pacific/Auckland
 
@@ -28,7 +29,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         graphviz \
         aspell \
         libldap2-dev \
-    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
     && docker-php-ext-install -j$(nproc) zip \
         intl \
         soap \
@@ -77,19 +77,19 @@ ENV LC_ALL en_US.UTF-8
 
 # install mssql extension
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
-    && curl https://packages.microsoft.com/config/debian/10/prod.list > /etc/apt/sources.list.d/mssql-release.list \
+    && curl https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list \
     && apt-get update && ACCEPT_EULA=Y apt-get install -y \
-    msodbcsql17 \
-    mssql-tools \
+    msodbcsql18 \
+    mssql-tools18 \
     unixodbc-dev
 
 # Workaround to get MSSQL connection working on Debian 10 (buster)
 # https://emacstragic.net/2017/11/06/mssql-odbc-client-on-debian-9-stretch/
-RUN wget "http://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u12_amd64.deb" \
-    && DEBIAN_FRONTEND=noninteractive dpkg -i ./libssl1.0.0_1.0.1t-1+deb8u12_amd64.deb
+#RUN wget "http://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u12_amd64.deb" \
+#    && DEBIAN_FRONTEND=noninteractive dpkg -i ./libssl1.0.0_1.0.1t-1+deb8u12_amd64.deb
 
-RUN echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bash_profile \
-    && echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc
+RUN echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bash_profile \
+    && echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bashrc
 
 RUN pear config-set php_ini `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"` system \
     && pecl install sqlsrv-5.10.0 \

--- a/php/php81/Dockerfile
+++ b/php/php81/Dockerfile
@@ -1,4 +1,5 @@
-FROM php:8.1-fpm-buster
+ARG ARCH=amd64
+FROM $ARCH/php:8.1-fpm-buster
 
 ARG TIME_ZONE=Pacific/Auckland
 
@@ -62,19 +63,19 @@ ENV LC_ALL en_US.UTF-8
 
 # install mssql extension
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
-    && curl https://packages.microsoft.com/config/debian/10/prod.list > /etc/apt/sources.list.d/mssql-release.list \
+    && curl https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list \
     && apt-get update && ACCEPT_EULA=Y apt-get install -y \
-    msodbcsql17 \
-    mssql-tools \
+    msodbcsql18 \
+    mssql-tools18 \
     unixodbc-dev
 
 # Workaround to get MSSQL connection working on Debian 10 (buster)
 # https://emacstragic.net/2017/11/06/mssql-odbc-client-on-debian-9-stretch/
-RUN wget "http://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u12_amd64.deb" \
-    && DEBIAN_FRONTEND=noninteractive dpkg -i ./libssl1.0.0_1.0.1t-1+deb8u12_amd64.deb
+#RUN wget "http://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u12_amd64.deb" \
+#    && DEBIAN_FRONTEND=noninteractive dpkg -i ./libssl1.0.0_1.0.1t-1+deb8u12_amd64.deb
 
-RUN echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bash_profile \
-    && echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc
+RUN echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bash_profile \
+    && echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bashrc
 
 RUN pear config-set php_ini `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"` system \
     && pecl install sqlsrv-5.10.0 \

--- a/php/php81/config/php.ini
+++ b/php/php81/config/php.ini
@@ -1,7 +1,6 @@
 log_errors = On
 error_log = /dev/stderr
 error_reporting = E_ALL & ~E_DEPRECATED
-max_input_vars = 2000
 date.timezone = Pacific/Auckland
 memory_limit=256M
 ; necessary as Xdebug impacts performance that hard


### PR DESCRIPTION
I replced the base image of apache, nginx, postgresql, nodejs, redis and memcache to alpine linux. 
The reason for replacement were that alpine linux is smaller and consume less resource and less vulnerability.
I will replace those php image in next commit.