### PR TITLE
Add pcov PHP extension for code coverage

### DIFF
--- a/php/php71-debug/Dockerfile
+++ b/php/php71-debug/Dockerfile
@@ -1,6 +1,7 @@
 FROM totara/docker-dev-php71:latest
 
 RUN pecl install -f xdebug-2.9.6 && docker-php-ext-enable xdebug.so
+RUN pecl install -f pcov && docker-php-ext-enable pcov.so
 
 RUN echo "xdebug.remote_enable=1" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.remote_autostart=0" >> /usr/local/etc/php/conf.d/xdebug.ini

--- a/php/php72-debug/Dockerfile
+++ b/php/php72-debug/Dockerfile
@@ -1,6 +1,7 @@
 FROM totara/docker-dev-php72:latest
 
 RUN pecl install -f xdebug-3.1.1 && docker-php-ext-enable xdebug.so
+RUN pecl install -f pcov && docker-php-ext-enable pcov.so
 
 RUN echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.start_with_request=trigger" >> /usr/local/etc/php/conf.d/xdebug.ini

--- a/php/php73-debug/Dockerfile
+++ b/php/php73-debug/Dockerfile
@@ -1,6 +1,7 @@
 FROM totara/docker-dev-php73:latest
 
 RUN pecl install -f xdebug-3.1.1 && docker-php-ext-enable xdebug.so
+RUN pecl install -f pcov && docker-php-ext-enable pcov.so
 
 RUN echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.start_with_request=trigger" >> /usr/local/etc/php/conf.d/xdebug.ini

--- a/php/php74-debug/Dockerfile
+++ b/php/php74-debug/Dockerfile
@@ -1,6 +1,7 @@
 FROM totara/docker-dev-php74:latest
 
 RUN pecl install -f xdebug-3.1.1 && docker-php-ext-enable xdebug.so
+RUN pecl install -f pcov && docker-php-ext-enable pcov.so
 
 RUN echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.start_with_request=trigger" >> /usr/local/etc/php/conf.d/xdebug.ini

--- a/php/php80-debug/Dockerfile
+++ b/php/php80-debug/Dockerfile
@@ -1,6 +1,7 @@
 FROM totara/docker-dev-php80:latest
 
 RUN pecl install -f xdebug-3.1.1 && docker-php-ext-enable xdebug.so
+RUN pecl install -f pcov && docker-php-ext-enable pcov.so
 
 RUN echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.start_with_request=trigger" >> /usr/local/etc/php/conf.d/xdebug.ini

--- a/php/php81-debug/Dockerfile
+++ b/php/php81-debug/Dockerfile
@@ -1,6 +1,7 @@
 FROM totara/docker-dev-php81:latest
 
 RUN pecl install -f xdebug-3.1.5 && docker-php-ext-enable xdebug.so
+RUN pecl install -f pcov && docker-php-ext-enable pcov.so
 
 RUN echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.start_with_request=trigger" >> /usr/local/etc/php/conf.d/xdebug.ini


### PR DESCRIPTION
To generate code coverage via PHPUnit the pcov extension is superior in terms of performance to xdebug. This PR adds the extension to the debug container.