### PR TITLE
Fix checknet.txt for SCORM not being able to called

### DIFF
--- a/apache/config/remote-server.conf
+++ b/apache/config/remote-server.conf
@@ -6,5 +6,6 @@ LimitRequestBody 10485760
 
 # Don't allow the following files/directories to be accessed
 RewriteRule (\/cli\/|\/tests\/|\/db\/|\/lang\/|\/classes\/|\/amd\/src\/|/rb_sources/|\/yui\/src\/|\/templates\/) - [R=404]
-RewriteRule \.(txt|md|json|xml|mustache) - [R=404]
 RewriteRule \/\. - [R=404]
+RewriteCond %{REQUEST_URI} !^/lib/yui/build/moodle-core-checknet/assets/checknet.txt$
+RewriteRule \.(txt|md|json|xml|mustache) - [R=404]

--- a/apache/config/remote-server.conf
+++ b/apache/config/remote-server.conf
@@ -5,7 +5,7 @@
 LimitRequestBody 10485760
 
 # Don't allow the following files/directories to be accessed
-RewriteRule (\/cli\/|\/tests\/|\/db\/|\/lang\/|\/classes\/|\/amd\/src\/|/rb_sources/|\/yui\/src\/|\/templates\/) - [R=404]
+RewriteRule (\/cli\/|\/tests\/|\/db\/|\/classes\/|\/amd\/src\/|/rb_sources/|\/yui\/src\/|\/templates\/) - [R=404]
 RewriteRule \/\. - [R=404]
 RewriteCond %{REQUEST_URI} !^/lib/yui/build/moodle-core-checknet/assets/checknet.txt$
 RewriteRule \.(txt|md|json|xml|mustache) - [R=404]

--- a/nginx/config/remote-server.conf
+++ b/nginx/config/remote-server.conf
@@ -30,7 +30,7 @@ location / {
     try_files $uri $uri/ =404;
 }
 
-location ~ ^.*\/(cli|tests|db|lang|classes|amd\/src|rb_sources|yui\/src)\/.*$ {
+location ~ ^.*\/(cli|tests|db|classes|amd\/src|rb_sources|yui\/src)\/.*$ {
     deny all;
 }
 

--- a/nginx/config/remote-server.conf
+++ b/nginx/config/remote-server.conf
@@ -63,4 +63,9 @@ location ~ /\. {
 
 location ~ .*\.(txt|md|json|xml|mustache)$ {
     deny all;
+
+    # Allow this one specifically to make sure SCORM network checks are successful
+    location ~ ^/lib/yui/build/moodle-core-checknet/assets/checknet.txt$ {
+        allow all;
+    }
 }


### PR DESCRIPTION
Fixes #232

To test this you'd need to build the image locally.

```
tstop nginx
tbuild apache & tup apache
# test that it works
tstop apache
tbuild nginx && tup nginx
# test that it works
```