### PR TITLE
Improve support for ARM chips like Mac M1 or M2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,20 +10,34 @@ env:
 - DOCKER_IMAGE=php/php53-debug
 - DOCKER_IMAGE=php/php54
 - DOCKER_IMAGE=php/php54-debug
+- DOCKER_IMAGE=php/php54-cron
 - DOCKER_IMAGE=php/php55
 - DOCKER_IMAGE=php/php55-debug
+- DOCKER_IMAGE=php/php55-cron
 - DOCKER_IMAGE=php/php56
 - DOCKER_IMAGE=php/php56-debug
+- DOCKER_IMAGE=php/php56-cron
 - DOCKER_IMAGE=php/php70
 - DOCKER_IMAGE=php/php70-debug
+- DOCKER_IMAGE=php/php70-cron
 - DOCKER_IMAGE=php/php71
 - DOCKER_IMAGE=php/php71-debug
+- DOCKER_IMAGE=php/php71-cron
 - DOCKER_IMAGE=php/php72
 - DOCKER_IMAGE=php/php72-debug
+- DOCKER_IMAGE=php/php72-cron
 - DOCKER_IMAGE=php/php73
 - DOCKER_IMAGE=php/php73-debug
+- DOCKER_IMAGE=php/php73-cron
 - DOCKER_IMAGE=php/php74
 - DOCKER_IMAGE=php/php74-debug
+- DOCKER_IMAGE=php/php74-cron
+- DOCKER_IMAGE=php/php80
+- DOCKER_IMAGE=php/php80-debug
+- DOCKER_IMAGE=php/php80-cron
+- DOCKER_IMAGE=php/php81
+- DOCKER_IMAGE=php/php81-debug
+- DOCKER_IMAGE=php/php81-cron
 
 services:
 - docker
@@ -32,7 +46,7 @@ install:
 - docker build -t ${DOCKER_IMAGE/\//-} $DOCKER_IMAGE
 - docker run --rm -d --name ${DOCKER_IMAGE/\//-} ${DOCKER_IMAGE/\//-}
 
-before_script:
+before_script: skip
 
 script:
 - docker ps | grep -q ${DOCKER_IMAGE/\//-}

--- a/bin/helpers/php_container.php
+++ b/bin/helpers/php_container.php
@@ -14,9 +14,9 @@ $site_path = $argv[1];
 $silent = !empty($argv[2]) && strpos($argv[2], 'silent') !== false;
 
 // Gets the ID & Name of the latest PHP container that can be used for this Totara version
-$php_container_ids = trim((string) shell_exec('docker ps -aqf "name=^totara_php" --format "{{.ID}}"'));
+$php_container_ids = trim((string) shell_exec('docker ps -af "name=^totara_php" --format "{{.ID}}"'));
 $php_container_ids = !empty($php_container_ids) ? preg_split('/\s+/',$php_container_ids) : array();
-$php_container_names = trim((string) shell_exec('docker ps -aqf "name=^totara_php" --format "{{.Names}}"'));
+$php_container_names = trim((string) shell_exec('docker ps -aaf "name=^totara_php" --format "{{.Names}}"'));
 $php_container_names = !empty($php_container_names) ? preg_split('/\s+/', $php_container_names) : array();
 $php_containers_running = array_combine($php_container_ids, $php_container_names);
 asort($php_containers_running);

--- a/bin/tdb
+++ b/bin/tdb
@@ -385,9 +385,16 @@ elif [ "$db_type" == 'mariadb' ]; then
 #          Microsoft SQL Server          #
 ##########################################
 elif [ "$db_type" == 'mssql' ]; then
+    # Newer PHP versions have a newer mssql-tools version
+    if [[ "$php_container_name" == 'php-5.6' || "$php_container_name" == 'php-7.0' || "$php_container_name" == 'php-7.1' || "$php_container_name" == 'php-7.2' ]]; then
+        sqlcmd="/opt/mssql-tools/bin/sqlcmd"
+    else
+        sqlcmd="/opt/mssql-tools18/bin/sqlcmd -C"
+    fi
+
     # Handles executing sql commands.
     function db_sql_cmd() {
-        command_output=$(eval "$php_command /opt/mssql-tools/bin/sqlcmd -S $db_host -U $db_user -P \"$db_password\" -q \"$1\"")
+        command_output=$(eval "$php_command $sqlcmd -S $db_host -U $db_user -P \"$db_password\" -q \"$1\"")
         error_msg=$(echo "$command_output" | grep 'Msg')
         if [ -z "$2" ]; then
             eval "$2"
@@ -426,7 +433,7 @@ elif [ "$db_type" == 'mssql' ]; then
 
     # Start mssql shell
     elif [ "$action" == 'shell' ]; then
-        docker exec -it "$db_container" /opt/mssql-tools/bin/sqlcmd -S "$db_host" -U "$db_user" -P "$db_password" -q "USE $db_name"
+        docker exec -it "$db_container" $sqlcmd -S "$db_host" -U "$db_user" -P "$db_password" -q "USE $db_name"
 
     # Handle unimplemented action
     else

--- a/compose/mssql.yml
+++ b/compose/mssql.yml
@@ -3,6 +3,8 @@ services:
 
   mssql:
     image: totara/docker-dev-mssql
+    # Mssql does not support multiple architectures
+    platform: linux/amd64
     container_name: totara_mssql
     ports:
       - "1433:1433"
@@ -20,6 +22,8 @@ services:
 
   mssql2019:
     image: totara/docker-dev-mssql2019
+    # Mssql does not support multiple architectures
+    platform: linux/amd64
     container_name: totara_mssql2019
     ports:
       - "1419:1433"

--- a/compose/mysql.yml
+++ b/compose/mysql.yml
@@ -18,8 +18,8 @@ services:
       - totara
 
   mysql:
-    # The mysql 5.7 image does not work on m1 macs. (mysql 8.0 works fine)
-    platform: linux/x86_64
+    # MySQL 5.7 does not support multiple architectures. (MySQL 8.0 works fine)
+    platform: linux/amd64
     image: mysql:5.7
     container_name: totara_mysql57
     ports:

--- a/compose/mysql.yml
+++ b/compose/mysql.yml
@@ -18,6 +18,8 @@ services:
       - totara
 
   mysql:
+    # The mysql 5.7 image does not work on m1 macs. (mysql 8.0 works fine)
+    platform: linux/x86_64
     image: mysql:5.7
     container_name: totara_mysql57
     ports:

--- a/php/php73/Dockerfile
+++ b/php/php73/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3-fpm-buster
+FROM php:7.3-fpm-bullseye
 
 ARG TIME_ZONE=Pacific/Auckland
 
@@ -30,7 +30,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         graphviz \
         aspell \
         libldap2-dev \
-    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
+        libltdl-dev \
     && docker-php-ext-install -j$(nproc) xmlrpc \
         zip \
         intl \
@@ -83,19 +83,20 @@ ENV LC_ALL en_US.UTF-8
 
 # install mssql extension
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
-    && curl https://packages.microsoft.com/config/debian/10/prod.list > /etc/apt/sources.list.d/mssql-release.list \
+    && curl https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list \
     && apt-get update && ACCEPT_EULA=Y apt-get install -y \
-        msodbcsql17 \
-        mssql-tools \
-        unixodbc-dev \
-    && rm -rf /var/lib/apt/lists/*
+    msodbcsql18 \
+    mssql-tools18 \
+    unixodbc-dev
 
 RUN echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bash_profile \
     && echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc
 
+# Workaround applied: https://github.com/microsoft/msphpsql/issues/1438#issuecomment-1444773949
 RUN pear config-set php_ini `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"` system \
-    && pecl install sqlsrv-5.9.0 \
-    && pecl install pdo_sqlsrv-5.9.0
+    && pecl install sqlsrv-5.9.0 pdo_sqlsrv-5.9.0 || \
+    apt-get install -y --allow-downgrades odbcinst=2.3.7 odbcinst1debian2=2.3.7 unixodbc=2.3.7 unixodbc-dev=2.3.7 && \
+    pecl install sqlsrv-5.9.0 pdo_sqlsrv-5.9.0
 
 RUN docker-php-ext-enable sqlsrv.so && docker-php-ext-enable pdo_sqlsrv.so
 
@@ -103,7 +104,7 @@ RUN ln -fs /usr/share/zoneinfo/${TIME_ZONE} /etc/localtime \
     && dpkg-reconfigure --frontend noninteractive tzdata
 
 # Python 3.7 for ML Recommender.
-RUN apt-get update && apt install -y python3.7 \
+RUN apt-get update && apt install -y python3 \
     python3-pip \
     python3-wheel \
     python3-venv \

--- a/php/php74/Dockerfile
+++ b/php/php74/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4-fpm-buster
+FROM php:7.4-fpm-bullseye
 
 ARG TIME_ZONE=Pacific/Auckland
 
@@ -28,7 +28,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         graphviz \
         aspell \
         libldap2-dev \
-    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
+        libltdl-dev \
     && docker-php-ext-install -j$(nproc) xmlrpc \
         zip \
         intl \
@@ -78,18 +78,20 @@ ENV LC_ALL en_US.UTF-8
 
 # install mssql extension
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
-    && curl https://packages.microsoft.com/config/debian/10/prod.list > /etc/apt/sources.list.d/mssql-release.list \
+    && curl https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list \
     && apt-get update && ACCEPT_EULA=Y apt-get install -y \
-    msodbcsql17 \
-    mssql-tools \
+    msodbcsql18 \
+    mssql-tools18 \
     unixodbc-dev
 
 RUN echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bash_profile \
     && echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc
 
+# Workaround applied: https://github.com/microsoft/msphpsql/issues/1438#issuecomment-1444773949
 RUN pear config-set php_ini `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"` system \
-    && pecl install sqlsrv-5.10.0 \
-    && pecl install pdo_sqlsrv-5.10.0
+    && pecl install sqlsrv-5.10.1 pdo_sqlsrv-5.10.1 || \
+    apt-get install -y --allow-downgrades odbcinst=2.3.7 odbcinst1debian2=2.3.7 unixodbc=2.3.7 unixodbc-dev=2.3.7 && \
+    pecl install sqlsrv-5.10.1 pdo_sqlsrv-5.10.1
 
 RUN docker-php-ext-enable sqlsrv.so && docker-php-ext-enable pdo_sqlsrv.so
 
@@ -97,7 +99,7 @@ RUN ln -fs /usr/share/zoneinfo/${TIME_ZONE} /etc/localtime \
     && dpkg-reconfigure --frontend noninteractive tzdata
 
 # Python 3.7 for ML Recommender.
-RUN apt-get update && apt install -y python3.7 \
+RUN apt-get update && apt install -y python3 \
     python3-pip \
     python3-wheel \
     python3-venv \

--- a/php/php80/Dockerfile
+++ b/php/php80/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         aspell \
         libldap2-dev \
         libltdl-dev \
-    && docker-php-ext-install -j$(nproc) xmlrpc \
+    && docker-php-ext-install -j$(nproc) \
         zip \
         intl \
         soap \

--- a/php/php80/Dockerfile
+++ b/php/php80/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.0-fpm-buster
+FROM php:8.0-fpm-bullseye
 
 ARG TIME_ZONE=Pacific/Auckland
 
@@ -28,8 +28,9 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         graphviz \
         aspell \
         libldap2-dev \
-    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
-    && docker-php-ext-install -j$(nproc) zip \
+        libltdl-dev \
+    && docker-php-ext-install -j$(nproc) xmlrpc \
+        zip \
         intl \
         soap \
         opcache \
@@ -77,18 +78,20 @@ ENV LC_ALL en_US.UTF-8
 
 # install mssql extension
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
-    && curl https://packages.microsoft.com/config/debian/10/prod.list > /etc/apt/sources.list.d/mssql-release.list \
+    && curl https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list \
     && apt-get update && ACCEPT_EULA=Y apt-get install -y \
-    msodbcsql17 \
-    mssql-tools \
+    msodbcsql18 \
+    mssql-tools18 \
     unixodbc-dev
 
 RUN echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bash_profile \
     && echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc
 
+# Workaround applied: https://github.com/microsoft/msphpsql/issues/1438#issuecomment-1444773949
 RUN pear config-set php_ini `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"` system \
-    && pecl install sqlsrv-5.10.0 \
-    && pecl install pdo_sqlsrv-5.10.0
+    && pecl install sqlsrv-5.10.1 pdo_sqlsrv-5.10.1 || \
+    apt-get install -y --allow-downgrades odbcinst=2.3.7 odbcinst1debian2=2.3.7 unixodbc=2.3.7 unixodbc-dev=2.3.7 && \
+    pecl install sqlsrv-5.10.1 pdo_sqlsrv-5.10.1
 
 RUN docker-php-ext-enable sqlsrv.so && docker-php-ext-enable pdo_sqlsrv.so
 
@@ -96,7 +99,7 @@ RUN ln -fs /usr/share/zoneinfo/${TIME_ZONE} /etc/localtime \
     && dpkg-reconfigure --frontend noninteractive tzdata
 
 # Python 3.7 for ML Recommender.
-RUN apt-get update && apt install -y python3.7 \
+RUN apt-get update && apt install -y python3 \
     python3-pip \
     python3-wheel \
     python3-venv \

--- a/php/php81/Dockerfile
+++ b/php/php81/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         aspell \
         libldap2-dev \
         libltdl-dev \
-    && docker-php-ext-install -j$(nproc) xmlrpc \
+    && docker-php-ext-install -j$(nproc) \
         zip \
         intl \
         soap \

--- a/php/php81/Dockerfile
+++ b/php/php81/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-fpm-buster
+FROM php:8.1-fpm-bullseye
 
 ARG TIME_ZONE=Pacific/Auckland
 
@@ -27,7 +27,10 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         ghostscript \
         graphviz \
         aspell \
-    && docker-php-ext-install -j$(nproc) zip \
+        libldap2-dev \
+        libltdl-dev \
+    && docker-php-ext-install -j$(nproc) xmlrpc \
+        zip \
         intl \
         soap \
         opcache \
@@ -36,6 +39,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         pgsql \
         mysqli \
         exif \
+        ldap \
     && docker-php-ext-configure gd \
             --with-freetype \
             --with-jpeg \
@@ -48,6 +52,18 @@ RUN git clone https://github.com/tideways/php-profiler-extension.git \
     && make && make install
 
 RUN echo "extension=tideways_xhprof.so" >> /usr/local/etc/php/conf.d/tideways_xhprof.ini
+
+RUN pecl install -o -f redis \
+    &&  rm -rf /tmp/pear \
+    &&  docker-php-ext-enable redis
+
+RUN pecl install -o -f igbinary \
+    &&  rm -rf /tmp/pear \
+    &&  docker-php-ext-enable igbinary
+
+RUN pecl install -o -f memcached \
+    &&  rm -rf /tmp/pear \
+    &&  docker-php-ext-enable memcached
 
 # we need en_US locales for MSSQL connection to work
 # we need en_AU locales for behat to work
@@ -62,23 +78,32 @@ ENV LC_ALL en_US.UTF-8
 
 # install mssql extension
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
-    && curl https://packages.microsoft.com/config/debian/10/prod.list > /etc/apt/sources.list.d/mssql-release.list \
+    && curl https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list \
     && apt-get update && ACCEPT_EULA=Y apt-get install -y \
-    msodbcsql17 \
-    mssql-tools \
+    msodbcsql18 \
+    mssql-tools18 \
     unixodbc-dev
 
 RUN echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bash_profile \
     && echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc
 
+# Workaround applied: https://github.com/microsoft/msphpsql/issues/1438#issuecomment-1444773949
 RUN pear config-set php_ini `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"` system \
-    && pecl install sqlsrv-5.10.0 \
-    && pecl install pdo_sqlsrv-5.10.0
+    && pecl install sqlsrv-5.10.1 pdo_sqlsrv-5.10.1 || \
+    apt-get install -y --allow-downgrades odbcinst=2.3.7 odbcinst1debian2=2.3.7 unixodbc=2.3.7 unixodbc-dev=2.3.7 && \
+    pecl install sqlsrv-5.10.1 pdo_sqlsrv-5.10.1
 
 RUN docker-php-ext-enable sqlsrv.so && docker-php-ext-enable pdo_sqlsrv.so
 
 RUN ln -fs /usr/share/zoneinfo/${TIME_ZONE} /etc/localtime \
     && dpkg-reconfigure --frontend noninteractive tzdata
+
+# Python 3.7 for ML Recommender.
+RUN apt-get update && apt install -y python3 \
+    python3-pip \
+    python3-wheel \
+    python3-venv \
+    python3-dev
 
 COPY config/php.ini /usr/local/etc/php/
 COPY config/fpm.conf /usr/local/etc/php-fpm.d/zz-totara.conf


### PR DESCRIPTION
This patch updates the PHP images to use the Debian bullseye base image which improves ARM support. At least for PHP 7.3 and newer. PHP 7.2 and lower is still built on top of Debian stretch or buster which likely has no ARM support for everything we need.

It also pins the MySQL 5.7 container on the amd64 platform as it does not support ARM yet.

Helps addressing #231 and #230.