### PR TITLE
Update postgres images, make sure all db services have versions in them

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@ Although this project started as a development environment for Totara Learn it c
  * [NGINX](https://nginx.org/) as a webserver
  * [Apache](https://httpd.apache.org/) as a webserver
  * [PHP](http://php.net/) 5.3, 5.4, 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1 to test for different versions
- * [PostgreSQL](https://www.postgresql.org/) (9.3, 9.6, 10, 11, 12, 13, 14), [MariaDB](https://mariadb.org/) (10.2, 10.3, 10.4, 10.5, 10.6, 10.7, 10.8), [MySQL](https://www.mysql.com/) (5.7, 8), and Microsoft SQL Server ([2017](https://www.microsoft.com/en-us/sql-server/sql-server-2017), [2019](https://www.microsoft.com/en-us/sql-server/sql-server-2019)) support
+ * [PostgreSQL](https://www.postgresql.org/) (9.3, 9.6, 10, 11, 12, 13, 14, 15), 
+ * [MariaDB](https://mariadb.org/) (10.2, 10.3, 10.4, 10.5, 10.6, 10.7, 10.8, 10.11), 
+ * [MySQL](https://www.mysql.com/) (5.7, 8), 
+ * Microsoft SQL Server ([2017](https://www.microsoft.com/en-us/sql-server/sql-server-2017), [2019](https://www.microsoft.com/en-us/sql-server/sql-server-2019))
  * [NodeJS](https://nodejs.org/) for building, developing and testing frontend code
  * A [PHPUnit](https://phpunit.de/) and [Behat](http://behat.org/en/latest/) setup to run tests (including [Selenium](https://www.seleniumhq.org/))
  * A [mailcatcher](https://mailcatcher.me/) instance to view sent emails
@@ -24,6 +27,7 @@ Although this project started as a development environment for Totara Learn it c
  * [XHProf](https://github.com/tideways/php-xhprof-extension) for profiling
  * [XDebug](https://xdebug.org/) installed, ready for debugging with your favorite IDE
  * A [Python](https://www.python.org/) instance to run the Totara Machine Learning service
+ * Optimised for [Apple Silicon](../../wiki/Apple-Silicon-support)
 
 ## Installation & Usage
 

--- a/bin/tdb
+++ b/bin/tdb
@@ -129,15 +129,7 @@ if [[ -n $2 ]]; then
 fi
 
 # Get the db container
-if [[ "$db_host" == 'pgsql' ]]; then
-    db_container_name='totara_pgsql12'
-elif [[ "$db_host" == 'mysql' ]]; then
-    db_container_name='totara_mysql57'
-elif [[ "$db_host" == 'mariadb' ]]; then
-    db_container_name='totara_mariadb105'
-else
-    db_container_name="totara_${db_host}"
-fi
+db_container_name="totara_${db_host}"
 db_containers=($(docker ps --filter "name=$db_host" --format '{{.ID}} {{.Names}}' | grep "$db_container_name" | xargs))
 if [ -z $db_containers ]; then
     tup "$db_host"

--- a/compose/build.yml
+++ b/compose/build.yml
@@ -7,7 +7,7 @@ services:
   nginx:
     build: ./nginx
 
-  mssql:
+  mssql2017:
     build:
       context: ./mssql
       dockerfile: 2017/Dockerfile

--- a/compose/mariadb.yml
+++ b/compose/mariadb.yml
@@ -1,22 +1,6 @@
 version: "3.7"
 services:
 
-  mariadb:
-    image: mariadb:10.5
-    container_name: totara_mariadb105
-    ports:
-      - "3307:3306"
-    environment:
-      TZ: ${TIME_ZONE}
-      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PW}
-    volumes:
-      - mariadb-data:/var/lib/mysql
-      - ./mariadb:/etc/mysql/conf.d
-    depends_on:
-      - nginx
-    networks:
-      - totara
-
   mariadb1011:
     image: mariadb:10.11
     container_name: totara_mariadb1011
@@ -75,6 +59,22 @@ services:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PW}
     volumes:
       - mariadb106-data:/var/lib/mysql
+      - ./mariadb:/etc/mysql/conf.d
+    depends_on:
+      - nginx
+    networks:
+      - totara
+
+  mariadb105:
+    image: mariadb:10.5
+    container_name: totara_mariadb105
+    ports:
+      - "3307:3306"
+    environment:
+      TZ: ${TIME_ZONE}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PW}
+    volumes:
+      - mariadb-data:/var/lib/mysql
       - ./mariadb:/etc/mysql/conf.d
     depends_on:
       - nginx

--- a/compose/mssql.yml
+++ b/compose/mssql.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
 
-  mssql:
+  mssql2017:
     image: totara/docker-dev-mssql
     # Mssql does not support multiple architectures
     platform: linux/amd64

--- a/compose/mysql.yml
+++ b/compose/mysql.yml
@@ -17,7 +17,7 @@ services:
     networks:
       - totara
 
-  mysql:
+  mysql57:
     # MySQL 5.7 does not support multiple architectures. (MySQL 8.0 works fine)
     platform: linux/amd64
     image: mysql:5.7

--- a/compose/pgsql.yml
+++ b/compose/pgsql.yml
@@ -2,7 +2,7 @@ version: "3.7"
 services:
 
   pgsql93:
-    image: postgres:9.3
+    image: postgres:9.3-alpine
     container_name: totara_pgsql93
     ports:
       - "5493:5432"
@@ -20,7 +20,7 @@ services:
       - totara
 
   pgsql96:
-    image: postgres:9.6
+    image: postgres:9.6-alpine
     container_name: totara_pgsql96
     ports:
       - "5496:5432"
@@ -39,7 +39,7 @@ services:
       - totara
 
   pgsql10:
-    image: postgres:10.6
+    image: postgres:10-alpine
     container_name: totara_pgsql10
     ports:
       - "5410:5432"
@@ -57,7 +57,7 @@ services:
       - totara
 
   pgsql11:
-    image: postgres:11.6
+    image: postgres:11-alpine
     container_name: totara_pgsql11
     ports:
       - "5411:5432"
@@ -74,8 +74,8 @@ services:
     networks:
       - totara
 
-  pgsql:
-    image: postgres:12.1
+  pgsql12:
+    image: postgres:12-alpine
     container_name: totara_pgsql12
     ports:
       - "5432:5432"
@@ -93,7 +93,7 @@ services:
       - totara
 
   pgsql13:
-    image: postgres:13.0
+    image: postgres:13-alpine
     container_name: totara_pgsql13
     ports:
       - "5442:5432"
@@ -112,7 +112,7 @@ services:
       - totara
 
   pgsql14:
-    image: postgres:14.0
+    image: postgres:14-alpine
     container_name: totara_pgsql14
     ports:
       - "5443:5432"

--- a/php/php56/Dockerfile-alpine
+++ b/php/php56/Dockerfile-alpine
@@ -1,0 +1,129 @@
+FROM php:5.6-fpm-alpine
+
+ARG TIME_ZONE=Pacific/Auckland
+
+#RUN sed -i s/deb.debian.org/archive.debian.org/g /etc/apt/sources.list \
+#    && sed -i 's|security.debian.org|archive.debian.org/|g' /etc/apt/sources.list \
+#    && sed -i '/stretch-updates/d' /etc/apt/sources.list
+
+#RUN apk add --no-cache --update \
+#        freetds-bin \
+#        freetds-common \
+#        freetds-dev \
+#        libpq-dev \
+#        freetype-dev \
+#        musl-locales
+
+RUN apk add --no-cache --update \
+    libgd libpng-dev libjpeg-turbo-dev freetype-dev \
+    libxml2-dev \
+    icu-dev \
+    postgresql-dev \
+#        musl \
+#        openssl-dev \
+#        pkgconf \
+#        libpq \
+#        libpq-dev \
+#        freetype-dev \
+#        libjpeg-turbo-dev \
+#        libmcrypt-dev \
+#        libpng-dev \
+#        libxml2-dev \
+#        icu-dev \
+#        nano \
+#        vim \
+#        git \
+#        musl \
+#        musl-utils \
+#        tzdata \
+#        libmemcached-dev \
+#        zip \
+#        bc \
+#        ghostscript \
+#        graphviz \
+#        aspell \
+#        wget \
+#        libldap \
+#        openldap-dev \
+#        bash \
+#        curl \
+#        autoconf \
+#        gcc \
+#        make \
+#        g++ \
+    && docker-php-ext-install -j$(nproc) xmlrpc \
+        zip \
+        intl \
+        soap \
+        opcache \
+        pdo_pgsql \
+        pdo_mysql \
+        pgsql \
+        mysqli \
+        exif \
+    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+    && docker-php-ext-install -j$(nproc) gd
+
+#RUN wget --no-check-certificate https://pecl.php.net/get/xhprof-0.9.4.tgz \
+#    && pecl install --offline ./xhprof-0.9.4.tgz
+#
+#RUN echo "extension=xhprof.so" >> /usr/local/etc/php/conf.d/tideways_xhprof.ini
+
+RUN pecl install xhprof-0.9.4 \
+    && docker-php-ext-enable xhprof
+
+RUN pecl install -o -f redis-4.3.0 \
+    &&  rm -rf /tmp/pear \
+    &&  docker-php-ext-enable redis
+
+RUN pecl install -o -f igbinary-2.0.8 \
+    &&  rm -rf /tmp/pear \
+    &&  docker-php-ext-enable igbinary
+
+RUN pecl install -o -f memcached-2.2.0 \
+    &&  rm -rf /tmp/pear \
+    &&  docker-php-ext-enable memcached
+
+# we need en_AU locales for behat to work
+#RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+#    sed -i -e 's/# en_AU.UTF-8 UTF-8/en_AU.UTF-8 UTF-8/' /etc/locale.gen && \
+#    dpkg-reconfigure --frontend=noninteractive locales && \
+#    update-locale LANG=en_US.UTF-8
+
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
+
+RUN apk add --no-cache --update \
+    libsybdb5 \
+    unixodbc \
+    libct4
+
+RUN cd /usr/lib && ln -s /usr/lib/x86_64-linux-gnu/libsybdb.a
+
+RUN docker-php-ext-install -j$(nproc) mssql
+
+COPY config/freetds.conf /etc/freetds/freetds.conf
+
+RUN cd / && git clone https://github.com/wolfcw/libfaketime.git \
+    && cd /libfaketime/src && make install
+
+RUN ln -fs /usr/share/zoneinfo/${TIME_ZONE} /etc/localtime \
+    && dpkg-reconfigure --frontend noninteractive tzdata
+
+COPY config/php.ini /usr/local/etc/php/php.ini
+COPY config/fpm.conf /usr/local/etc/php-fpm.d/zz-totara.conf
+
+# Source each .sh file found in the /shell/ folder
+RUN echo 'for f in ~/custom_shell/*.sh; do [[ -e "$f" ]] && source "$f"; done;' >> ~/.bashrc
+
+# Have the option of using the oh my zsh shell.
+RUN apk add --no-cache --update zsh
+RUN sh -c "$(curl https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)" --unattended
+RUN git clone https://github.com/romkatv/powerlevel10k ~/.oh-my-zsh/custom/themes/powerlevel10k
+RUN git clone https://github.com/zsh-users/zsh-autosuggestions ~/.oh-my-zsh/custom/plugins/zsh-autosuggestions
+RUN git clone https://github.com/zsh-users/zsh-completions ~/.oh-my-zsh/custom/plugins/zsh-completions
+RUN git clone https://github.com/zsh-users/zsh-syntax-highlighting ~/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting
+RUN echo 'setopt +o nomatch' > ~/.zshrc
+RUN echo 'source ~/custom_shell/.zshrc' >> ~/.zshrc
+RUN cat ~/.bashrc >> ~/.zshrc

--- a/php/php80/Dockerfile-alpine
+++ b/php/php80/Dockerfile-alpine
@@ -1,0 +1,130 @@
+FROM php:8.0-fpm-buster
+
+ARG TIME_ZONE=Pacific/Auckland
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        apt-transport-https \
+        libfreetype6-dev \
+        libjpeg62-turbo-dev \
+        libmcrypt-dev \
+        libpng-dev \
+        libxml2-dev \
+        libicu-dev \
+        libpq-dev \
+        gnupg2 \
+        nano \
+        vim \
+        wget \
+        openssl \
+        locales \
+        tzdata \
+        git \
+        libzip-dev \
+        libmemcached-dev \
+        zip \
+        netcat \
+        bc \
+        ghostscript \
+        graphviz \
+        aspell \
+        libldap2-dev \
+    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
+    && docker-php-ext-install -j$(nproc) zip \
+        intl \
+        soap \
+        opcache \
+        pdo_pgsql \
+        pdo_mysql \
+        pgsql \
+        mysqli \
+        exif \
+        ldap \
+    && docker-php-ext-configure gd \
+            --with-freetype \
+            --with-jpeg \
+    && docker-php-ext-install -j$(nproc) gd
+
+RUN git clone https://github.com/tideways/php-profiler-extension.git \
+    && cd php-profiler-extension \
+    && phpize \
+    && ./configure \
+    && make && make install
+
+RUN echo "extension=tideways_xhprof.so" >> /usr/local/etc/php/conf.d/tideways_xhprof.ini
+
+RUN pecl install -o -f redis \
+    &&  rm -rf /tmp/pear \
+    &&  docker-php-ext-enable redis
+
+RUN pecl install -o -f igbinary \
+    &&  rm -rf /tmp/pear \
+    &&  docker-php-ext-enable igbinary
+
+RUN pecl install -o -f memcached \
+    &&  rm -rf /tmp/pear \
+    &&  docker-php-ext-enable memcached
+
+# we need en_US locales for MSSQL connection to work
+# we need en_AU locales for behat to work
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    sed -i -e 's/# en_AU.UTF-8 UTF-8/en_AU.UTF-8 UTF-8/' /etc/locale.gen && \
+    dpkg-reconfigure --frontend=noninteractive locales && \
+    update-locale LANG=en_US.UTF-8
+
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
+
+# install mssql extension
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
+    && curl https://packages.microsoft.com/config/debian/10/prod.list > /etc/apt/sources.list.d/mssql-release.list \
+    && apt-get update && ACCEPT_EULA=Y apt-get install -y \
+    msodbcsql17 \
+    mssql-tools \
+    unixodbc-dev
+
+# Workaround to get MSSQL connection working on Debian 10 (buster)
+# https://emacstragic.net/2017/11/06/mssql-odbc-client-on-debian-9-stretch/
+RUN wget "http://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl1.1_1.1.1n-0+deb10u5_amd64.deb" \
+    && DEBIAN_FRONTEND=noninteractive dpkg -i ./libssl1.1_1.1.1n-0+deb10u5_amd64.deb
+
+RUN echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bash_profile \
+    && echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc
+
+RUN pear config-set php_ini `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"` system \
+    && pecl install sqlsrv-5.10.0 \
+    && pecl install pdo_sqlsrv-5.10.0
+
+RUN docker-php-ext-enable sqlsrv.so && docker-php-ext-enable pdo_sqlsrv.so
+
+RUN ln -fs /usr/share/zoneinfo/${TIME_ZONE} /etc/localtime \
+    && dpkg-reconfigure --frontend noninteractive tzdata
+
+# Python 3.7 for ML Recommender.
+RUN apt-get update && apt install -y python3.7 \
+    python3-pip \
+    python3-wheel \
+    python3-venv \
+    python3-dev
+
+RUN pecl install -f xdebug-3.2.1 && docker-php-ext-enable xdebug.so
+
+COPY config/php.ini /usr/local/etc/php/
+COPY config/fpm.conf /usr/local/etc/php-fpm.d/zz-totara.conf
+
+RUN echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
+    && echo "xdebug.start_with_request=trigger" >> /usr/local/etc/php/conf.d/xdebug.ini
+
+# Source each .sh file found in the /shell/ folder
+RUN echo 'for f in ~/custom_shell/*.sh; do [[ -e "$f" ]] && source "$f"; done;' >> ~/.bashrc
+
+# Have the option of using the oh my zsh shell.
+RUN apt-get update && apt-get install -y zsh
+RUN sh -c "$(curl https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)" --unattended
+RUN git clone https://github.com/romkatv/powerlevel10k ~/.oh-my-zsh/custom/themes/powerlevel10k
+RUN git clone https://github.com/zsh-users/zsh-autosuggestions ~/.oh-my-zsh/custom/plugins/zsh-autosuggestions
+RUN git clone https://github.com/zsh-users/zsh-completions ~/.oh-my-zsh/custom/plugins/zsh-completions
+RUN git clone https://github.com/zsh-users/zsh-syntax-highlighting ~/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting
+RUN echo 'setopt +o nomatch' > ~/.zshrc
+RUN echo 'source ~/custom_shell/.zshrc' >> ~/.zshrc
+RUN cat ~/.bashrc >> ~/.zshrc

--- a/php/php80/Dockerfile-bullseye
+++ b/php/php80/Dockerfile-bullseye
@@ -1,0 +1,137 @@
+FROM php:8.0-fpm
+
+ARG TIME_ZONE=Pacific/Auckland
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        apt-transport-https \
+        libfreetype6-dev \
+        libjpeg62-turbo-dev \
+        libmcrypt-dev \
+        libpng-dev \
+        libxml2-dev \
+        libicu-dev \
+        libpq-dev \
+        gnupg2 \
+        nano \
+        vim \
+        wget \
+        openssl \
+        locales \
+        tzdata \
+        git \
+        libzip-dev \
+        libmemcached-dev \
+        zip \
+        netcat \
+        bc \
+        ghostscript \
+        graphviz \
+        aspell \
+        libldap2-dev \
+    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
+    && docker-php-ext-install -j$(nproc) zip \
+        intl \
+        soap \
+        opcache \
+        pdo_pgsql \
+        pdo_mysql \
+        pgsql \
+        mysqli \
+        exif \
+        ldap \
+    && docker-php-ext-configure gd \
+            --with-freetype \
+            --with-jpeg \
+    && docker-php-ext-install -j$(nproc) gd
+
+RUN git clone https://github.com/tideways/php-profiler-extension.git \
+    && cd php-profiler-extension \
+    && phpize \
+    && ./configure \
+    && make && make install
+
+RUN echo "extension=tideways_xhprof.so" >> /usr/local/etc/php/conf.d/tideways_xhprof.ini
+
+RUN pecl install -o -f redis \
+    &&  rm -rf /tmp/pear \
+    &&  docker-php-ext-enable redis
+
+RUN pecl install -o -f igbinary \
+    &&  rm -rf /tmp/pear \
+    &&  docker-php-ext-enable igbinary
+
+RUN pecl install -o -f memcached \
+    &&  rm -rf /tmp/pear \
+    &&  docker-php-ext-enable memcached
+
+# we need en_US locales for MSSQL connection to work
+# we need en_AU locales for behat to work
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    sed -i -e 's/# en_AU.UTF-8 UTF-8/en_AU.UTF-8 UTF-8/' /etc/locale.gen && \
+    dpkg-reconfigure --frontend=noninteractive locales && \
+    update-locale LANG=en_US.UTF-8
+
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
+
+# Workaround to avoid an ODBC PreDepend error about multi-arch support that is not installable
+# see https://github.com/totara/totara-docker-dev/issues/237
+RUN wget "http://archive.ubuntu.com/ubuntu/pool/main/g/glibc/multiarch-support_2.27-3ubuntu1.6_amd64.deb" \
+    && DEBIAN_FRONTEND=noninteractive dpkg -i ./multiarch-support_2.27-3ubuntu1.6_amd64.deb
+
+# install mssql extension
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
+    && curl https://packages.microsoft.com/config/debian/10/prod.list > /etc/apt/sources.list.d/mssql-release.list \
+    && apt-get update && ACCEPT_EULA=Y apt-get install -y \
+    msodbcsql17 \
+    mssql-tools \
+    unixodbc-dev
+
+# This is to avoid an error about a missing odbc library
+# see: https://github.com/microsoft/msphpsql/issues/1438
+RUN apt-get update && ACCEPT_EULA=Y apt-get install -y --allow-downgrades odbcinst=2.3.7 \
+    odbcinst1debian2=2.3.7 \
+    unixodbc=2.3.7 \
+    unixodbc-dev=2.3.7
+
+# Workaround to get MSSQL connection working on Debian 10 (buster)
+# https://emacstragic.net/2017/11/06/mssql-odbc-client-on-debian-9-stretch/
+RUN wget "http://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl1.1_1.1.1n-0+deb10u5_amd64.deb" \
+    && DEBIAN_FRONTEND=noninteractive dpkg -i ./libssl1.1_1.1.1n-0+deb10u5_amd64.deb
+
+RUN echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bash_profile \
+    && echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc
+
+RUN pear config-set php_ini `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"` system \
+    && pecl install sqlsrv-5.10.0 \
+    && pecl install pdo_sqlsrv-5.10.0
+
+RUN docker-php-ext-enable sqlsrv.so && docker-php-ext-enable pdo_sqlsrv.so
+
+RUN ln -fs /usr/share/zoneinfo/${TIME_ZONE} /etc/localtime \
+    && dpkg-reconfigure --frontend noninteractive tzdata
+
+# Python 3.7 for ML Recommender.
+RUN apt-get update && apt install -y python3.9 \
+    python3-pip \
+    python3-wheel \
+    python3-venv \
+    python3-dev
+
+COPY config/php.ini /usr/local/etc/php/
+COPY config/fpm.conf /usr/local/etc/php-fpm.d/zz-totara.conf
+
+# Source each .sh file found in the /shell/ folder
+RUN echo 'for f in ~/custom_shell/*.sh; do [[ -e "$f" ]] && source "$f"; done;' >> ~/.bashrc
+
+# Have the option of using the oh my zsh shell.
+RUN apt-get update && apt-get install -y zsh
+RUN sh -c "$(curl https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)" --unattended
+RUN git clone https://github.com/romkatv/powerlevel10k ~/.oh-my-zsh/custom/themes/powerlevel10k
+RUN git clone https://github.com/zsh-users/zsh-autosuggestions ~/.oh-my-zsh/custom/plugins/zsh-autosuggestions
+RUN git clone https://github.com/zsh-users/zsh-completions ~/.oh-my-zsh/custom/plugins/zsh-completions
+RUN git clone https://github.com/zsh-users/zsh-syntax-highlighting ~/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting
+RUN echo 'setopt +o nomatch' > ~/.zshrc
+RUN echo 'source ~/custom_shell/.zshrc' >> ~/.zshrc
+RUN cat ~/.bashrc >> ~/.zshrc

--- a/php/php80/Dockerfile-buster
+++ b/php/php80/Dockerfile-buster
@@ -1,0 +1,125 @@
+FROM php:8.0-fpm-buster
+
+ARG TIME_ZONE=Pacific/Auckland
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        apt-transport-https \
+        libfreetype6-dev \
+        libjpeg62-turbo-dev \
+        libmcrypt-dev \
+        libpng-dev \
+        libxml2-dev \
+        libicu-dev \
+        libpq-dev \
+        gnupg2 \
+        nano \
+        vim \
+        wget \
+        openssl \
+        locales \
+        tzdata \
+        git \
+        libzip-dev \
+        libmemcached-dev \
+        zip \
+        netcat \
+        bc \
+        ghostscript \
+        graphviz \
+        aspell \
+        libldap2-dev \
+    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
+    && docker-php-ext-install -j$(nproc) zip \
+        intl \
+        soap \
+        opcache \
+        pdo_pgsql \
+        pdo_mysql \
+        pgsql \
+        mysqli \
+        exif \
+        ldap \
+    && docker-php-ext-configure gd \
+            --with-freetype \
+            --with-jpeg \
+    && docker-php-ext-install -j$(nproc) gd
+
+RUN git clone https://github.com/tideways/php-profiler-extension.git \
+    && cd php-profiler-extension \
+    && phpize \
+    && ./configure \
+    && make && make install
+
+RUN echo "extension=tideways_xhprof.so" >> /usr/local/etc/php/conf.d/tideways_xhprof.ini
+
+RUN pecl install -o -f redis \
+    &&  rm -rf /tmp/pear \
+    &&  docker-php-ext-enable redis
+
+RUN pecl install -o -f igbinary \
+    &&  rm -rf /tmp/pear \
+    &&  docker-php-ext-enable igbinary
+
+RUN pecl install -o -f memcached \
+    &&  rm -rf /tmp/pear \
+    &&  docker-php-ext-enable memcached
+
+# we need en_US locales for MSSQL connection to work
+# we need en_AU locales for behat to work
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    sed -i -e 's/# en_AU.UTF-8 UTF-8/en_AU.UTF-8 UTF-8/' /etc/locale.gen && \
+    dpkg-reconfigure --frontend=noninteractive locales && \
+    update-locale LANG=en_US.UTF-8
+
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
+
+# install mssql extension
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
+    && curl https://packages.microsoft.com/config/debian/10/prod.list > /etc/apt/sources.list.d/mssql-release.list \
+    && apt-get update && ACCEPT_EULA=Y apt-get install -y \
+    msodbcsql17 \
+    mssql-tools \
+    unixodbc-dev
+
+# Workaround to get MSSQL connection working on Debian 10 (buster)
+# https://emacstragic.net/2017/11/06/mssql-odbc-client-on-debian-9-stretch/
+RUN wget "http://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u12_amd64.deb" \
+    && DEBIAN_FRONTEND=noninteractive dpkg -i ./libssl1.0.0_1.0.1t-1+deb8u12_amd64.deb
+
+RUN echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bash_profile \
+    && echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc
+
+RUN pear config-set php_ini `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"` system \
+    && pecl install sqlsrv-5.10.0 \
+    && pecl install pdo_sqlsrv-5.10.0
+
+RUN docker-php-ext-enable sqlsrv.so && docker-php-ext-enable pdo_sqlsrv.so
+
+RUN ln -fs /usr/share/zoneinfo/${TIME_ZONE} /etc/localtime \
+    && dpkg-reconfigure --frontend noninteractive tzdata
+
+# Python 3.7 for ML Recommender.
+RUN apt-get update && apt install -y python3.7 \
+    python3-pip \
+    python3-wheel \
+    python3-venv \
+    python3-dev
+
+COPY config/php.ini /usr/local/etc/php/
+COPY config/fpm.conf /usr/local/etc/php-fpm.d/zz-totara.conf
+
+# Source each .sh file found in the /shell/ folder
+RUN echo 'for f in ~/custom_shell/*.sh; do [[ -e "$f" ]] && source "$f"; done;' >> ~/.bashrc
+
+# Have the option of using the oh my zsh shell.
+RUN apt-get update && apt-get install -y zsh
+RUN sh -c "$(curl https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)" --unattended
+RUN git clone https://github.com/romkatv/powerlevel10k ~/.oh-my-zsh/custom/themes/powerlevel10k
+RUN git clone https://github.com/zsh-users/zsh-autosuggestions ~/.oh-my-zsh/custom/plugins/zsh-autosuggestions
+RUN git clone https://github.com/zsh-users/zsh-completions ~/.oh-my-zsh/custom/plugins/zsh-completions
+RUN git clone https://github.com/zsh-users/zsh-syntax-highlighting ~/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting
+RUN echo 'setopt +o nomatch' > ~/.zshrc
+RUN echo 'source ~/custom_shell/.zshrc' >> ~/.zshrc
+RUN cat ~/.bashrc >> ~/.zshrc

--- a/use-mutagen
+++ b/use-mutagen
@@ -1,0 +1,2 @@
+# copy this file to .use-mutagen to enable mutagen syncing.
+# Follow instructions in the README


### PR DESCRIPTION
Addresses #159

This requires a few steps when you are using the affected services (mysql, mssql, pgsql, mariadb):

1. Stop the container, e.g. `tstop mysql`
2. Remove the old container, e.g. `docker container rm totara_mysql57`
3. Pull the changes
4. Then start the container with `tdocker up -d --remove-orphans mysql57`

If you follow these steps the data should still be there. Of course you need to update your config.php to connect to `mysql57` instead of `mysql`.