### PR TITLE
Adding PHP 8.2 & 8.3 (RC) images

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Although this project started as a development environment for Totara Learn it c
 ### What You Get
  * [NGINX](https://nginx.org/) as a webserver
  * [Apache](https://httpd.apache.org/) as a webserver
- * [PHP](http://php.net/) 5.3, 5.4, 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1, 8.2 to test for different versions
+ * [PHP](http://php.net/) 5.3, 5.4, 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3RC5 to test for different versions
  * [PostgreSQL](https://www.postgresql.org/) (9.3, 9.6, 10, 11, 12, 13, 14, 15), 
  * [MariaDB](https://mariadb.org/) (10.2, 10.3, 10.4, 10.5, 10.6, 10.7, 10.8, 10.11), 
  * [MySQL](https://www.mysql.com/) (5.7, 8), 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Although this project started as a development environment for Totara Learn it c
 ### What You Get
  * [NGINX](https://nginx.org/) as a webserver
  * [Apache](https://httpd.apache.org/) as a webserver
- * [PHP](http://php.net/) 5.3, 5.4, 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1 to test for different versions
+ * [PHP](http://php.net/) 5.3, 5.4, 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1, 8.2 to test for different versions
  * [PostgreSQL](https://www.postgresql.org/) (9.3, 9.6, 10, 11, 12, 13, 14, 15), 
  * [MariaDB](https://mariadb.org/) (10.2, 10.3, 10.4, 10.5, 10.6, 10.7, 10.8, 10.11), 
  * [MySQL](https://www.mysql.com/) (5.7, 8), 

--- a/compose/php.yml
+++ b/compose/php.yml
@@ -610,6 +610,56 @@ services:
     networks:
       - totara
 
+  php-8.3:
+    image: totara/docker-dev-php83
+    container_name: totara_php83
+    working_dir: ${REMOTE_SRC}
+    environment:
+      CONTAINERNAME: php-8.3
+      HIST_FILE: /root/.bash_history
+      DISABLE_AUTO_UPDATE: "true" # disables oh-my-zsh update message
+    volumes:
+      - ${LOCAL_SRC}:${REMOTE_SRC}
+      - totara-data:${REMOTE_DATA}
+      - $HOME/.bash_history:/root/.bash_history
+      - zsh-history:/root/.zsh_history
+      - ./shell:/root/custom_shell
+    depends_on:
+      - php-8.3-debug
+    networks:
+      - totara
+
+  php-8.3-cron:
+    image: totara/docker-dev-php83-cron
+    container_name: totara_php83_cron
+    volumes:
+      - ${LOCAL_SRC}:${REMOTE_SRC}
+      - totara-data:${REMOTE_DATA}
+      - ./cron.d:/etc/cron.d
+    networks:
+      - totara
+
+  php-8.3-debug:
+    image: totara/docker-dev-php83-debug
+    container_name: totara_php83_debug
+    working_dir: ${REMOTE_SRC}
+    environment:
+      CONTAINERNAME: php-8.3-debug
+      TZ: ${TIME_ZONE}
+      XDEBUG_CONFIG: client_host=${HOST_IP}
+      XDEBUG_SESSION: totara83
+      PHP_IDE_CONFIG: serverName=totara83
+      HIST_FILE: /root/.bash_history
+      DISABLE_AUTO_UPDATE: "true" # disables oh-my-zsh update message
+    volumes:
+      - ${LOCAL_SRC}:${REMOTE_SRC}
+      - totara-data:${REMOTE_DATA}
+      - $HOME/.bash_history:/root/.bash_history
+      - zsh-history:/root/.zsh_history
+      - ./shell:/root/custom_shell
+    networks:
+      - totara
+
 volumes:
   totara-data:
   zsh-history:

--- a/compose/php.yml
+++ b/compose/php.yml
@@ -560,6 +560,56 @@ services:
     networks:
       - totara
 
+  php-8.2:
+    image: totara/docker-dev-php82
+    container_name: totara_php82
+    working_dir: ${REMOTE_SRC}
+    environment:
+      CONTAINERNAME: php-8.2
+      HIST_FILE: /root/.bash_history
+      DISABLE_AUTO_UPDATE: "true" # disables oh-my-zsh update message
+    volumes:
+      - ${LOCAL_SRC}:${REMOTE_SRC}
+      - totara-data:${REMOTE_DATA}
+      - $HOME/.bash_history:/root/.bash_history
+      - zsh-history:/root/.zsh_history
+      - ./shell:/root/custom_shell
+    depends_on:
+      - php-8.2-debug
+    networks:
+      - totara
+
+  php-8.2-cron:
+    image: totara/docker-dev-php82-cron
+    container_name: totara_php82_cron
+    volumes:
+      - ${LOCAL_SRC}:${REMOTE_SRC}
+      - totara-data:${REMOTE_DATA}
+      - ./cron.d:/etc/cron.d
+    networks:
+      - totara
+
+  php-8.2-debug:
+    image: totara/docker-dev-php82-debug
+    container_name: totara_php82_debug
+    working_dir: ${REMOTE_SRC}
+    environment:
+      CONTAINERNAME: php-8.2-debug
+      TZ: ${TIME_ZONE}
+      XDEBUG_CONFIG: client_host=${HOST_IP}
+      XDEBUG_SESSION: totara82
+      PHP_IDE_CONFIG: serverName=totara82
+      HIST_FILE: /root/.bash_history
+      DISABLE_AUTO_UPDATE: "true" # disables oh-my-zsh update message
+    volumes:
+      - ${LOCAL_SRC}:${REMOTE_SRC}
+      - totara-data:${REMOTE_DATA}
+      - $HOME/.bash_history:/root/.bash_history
+      - zsh-history:/root/.zsh_history
+      - ./shell:/root/custom_shell
+    networks:
+      - totara
+
 volumes:
   totara-data:
   zsh-history:

--- a/php/php82-cron/Dockerfile
+++ b/php/php82-cron/Dockerfile
@@ -1,0 +1,9 @@
+FROM totara/docker-dev-php82:latest
+
+RUN apt-get update && apt-get install -y cron
+
+COPY entrypoint.sh /entrypoint.sh
+
+RUN chmod +x /entrypoint.sh
+
+CMD /entrypoint.sh

--- a/php/php82-cron/entrypoint.sh
+++ b/php/php82-cron/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [ -e /etc/cron.d/*.cron ]
+then
+    # Install new crontab using all .cron files
+    cat /etc/cron.d/*.cron | crontab - \
+    && crontab -l \
+    && cron -f
+else
+    echo "No .cron files found in cron.d folder"
+fi

--- a/php/php82-debug/Dockerfile
+++ b/php/php82-debug/Dockerfile
@@ -1,0 +1,7 @@
+FROM totara/docker-dev-php82:latest
+
+RUN pecl install -f xdebug-3.2.2 && docker-php-ext-enable xdebug.so
+RUN pecl install -f pcov && docker-php-ext-enable pcov.so
+
+RUN echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
+    && echo "xdebug.start_with_request=trigger" >> /usr/local/etc/php/conf.d/xdebug.ini

--- a/php/php82/Dockerfile
+++ b/php/php82/Dockerfile
@@ -1,0 +1,117 @@
+FROM php:8.2-fpm-bullseye
+
+ARG TIME_ZONE=Pacific/Auckland
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        apt-transport-https \
+        libfreetype6-dev \
+        libjpeg62-turbo-dev \
+        libmcrypt-dev \
+        libpng-dev \
+        libxml2-dev \
+        libicu-dev \
+        libpq-dev \
+        gnupg2 \
+        nano \
+        vim \
+        wget \
+        openssl \
+        locales \
+        tzdata \
+        git \
+        libzip-dev \
+        libmemcached-dev \
+        zip \
+        netcat \
+        bc \
+        ghostscript \
+        graphviz \
+        aspell \
+        libldap2-dev \
+        libltdl-dev \
+    && docker-php-ext-install -j$(nproc) \
+        zip \
+        intl \
+        soap \
+        opcache \
+        pdo_pgsql \
+        pdo_mysql \
+        pgsql \
+        mysqli \
+        exif \
+        ldap \
+    && docker-php-ext-configure gd \
+            --with-freetype \
+            --with-jpeg \
+    && docker-php-ext-install -j$(nproc) gd
+
+RUN git clone https://github.com/tideways/php-profiler-extension.git \
+    && cd php-profiler-extension \
+    && phpize \
+    && ./configure \
+    && make && make install
+
+RUN echo "extension=tideways_xhprof.so" >> /usr/local/etc/php/conf.d/tideways_xhprof.ini
+
+RUN pecl install -o -f redis \
+    &&  rm -rf /tmp/pear \
+    &&  docker-php-ext-enable redis
+
+RUN pecl install -o -f igbinary \
+    &&  rm -rf /tmp/pear \
+    &&  docker-php-ext-enable igbinary
+
+RUN pecl install -o -f memcached \
+    &&  rm -rf /tmp/pear \
+    &&  docker-php-ext-enable memcached
+
+# we need en_US locales for MSSQL connection to work
+# we need en_AU locales for behat to work
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    sed -i -e 's/# en_AU.UTF-8 UTF-8/en_AU.UTF-8 UTF-8/' /etc/locale.gen && \
+    dpkg-reconfigure --frontend=noninteractive locales && \
+    update-locale LANG=en_US.UTF-8
+
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
+
+# install mssql extension
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
+    && curl https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list \
+    && apt-get update && ACCEPT_EULA=Y apt-get install -y \
+    msodbcsql18 \
+    mssql-tools18 \
+    unixodbc-dev
+
+RUN echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bash_profile \
+    && echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc
+
+# Workaround applied: https://github.com/microsoft/msphpsql/issues/1438#issuecomment-1444773949
+RUN pear config-set php_ini `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"` system \
+    && pecl install sqlsrv-5.10.1 pdo_sqlsrv-5.10.1 || \
+    apt-get install -y --allow-downgrades odbcinst=2.3.7 odbcinst1debian2=2.3.7 unixodbc=2.3.7 unixodbc-dev=2.3.7 && \
+    pecl install sqlsrv-5.10.1 pdo_sqlsrv-5.10.1
+
+RUN docker-php-ext-enable sqlsrv.so && docker-php-ext-enable pdo_sqlsrv.so
+
+RUN ln -fs /usr/share/zoneinfo/${TIME_ZONE} /etc/localtime \
+    && dpkg-reconfigure --frontend noninteractive tzdata
+
+COPY config/php.ini /usr/local/etc/php/
+COPY config/fpm.conf /usr/local/etc/php-fpm.d/zz-totara.conf
+
+# Source each .sh file found in the /shell/ folder, always source the default_aliases.sh file first
+RUN echo 'if [[ -e "/root/custom_shell/default-aliases.sh" ]] then source "/root/custom_shell/default-aliases.sh"; fi' >> ~/.bashrc && \
+  echo 'for f in /root/custom_shell/*.sh; do [[ "$f" != "/root/custom_shell/default-aliases.sh" && -e "$f" ]] && source "$f"; done;' >> ~/.bashrc
+
+# Have the option of using the oh my zsh shell.
+RUN apt-get update && apt-get install -y zsh
+RUN sh -c "$(curl https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)" --unattended
+RUN git clone https://github.com/romkatv/powerlevel10k ~/.oh-my-zsh/custom/themes/powerlevel10k
+RUN git clone https://github.com/zsh-users/zsh-autosuggestions ~/.oh-my-zsh/custom/plugins/zsh-autosuggestions
+RUN git clone https://github.com/zsh-users/zsh-completions ~/.oh-my-zsh/custom/plugins/zsh-completions
+RUN git clone https://github.com/zsh-users/zsh-syntax-highlighting ~/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting
+RUN echo 'setopt +o nomatch' > ~/.zshrc
+RUN echo 'source ~/custom_shell/.zshrc' >> ~/.zshrc
+RUN cat ~/.bashrc >> ~/.zshrc

--- a/php/php82/config/fpm.conf
+++ b/php/php82/config/fpm.conf
@@ -1,0 +1,2 @@
+[www]
+pm.max_children = 50

--- a/php/php82/config/php.ini
+++ b/php/php82/config/php.ini
@@ -1,0 +1,10 @@
+log_errors = On
+error_log = /dev/stderr
+error_reporting = E_ALL & ~E_DEPRECATED
+max_input_vars=5000
+date.timezone = Pacific/Auckland
+memory_limit=256M
+; necessary as Xdebug impacts performance that hard
+max_execution_time=120
+post_max_size = 64M
+upload_max_filesize = 64M

--- a/php/php83-cron/Dockerfile
+++ b/php/php83-cron/Dockerfile
@@ -1,0 +1,9 @@
+FROM totara/docker-dev-php83:latest
+
+RUN apt-get update && apt-get install -y cron
+
+COPY entrypoint.sh /entrypoint.sh
+
+RUN chmod +x /entrypoint.sh
+
+CMD /entrypoint.sh

--- a/php/php83-cron/entrypoint.sh
+++ b/php/php83-cron/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [ -e /etc/cron.d/*.cron ]
+then
+    # Install new crontab using all .cron files
+    cat /etc/cron.d/*.cron | crontab - \
+    && crontab -l \
+    && cron -f
+else
+    echo "No .cron files found in cron.d folder"
+fi

--- a/php/php83-debug/Dockerfile
+++ b/php/php83-debug/Dockerfile
@@ -1,0 +1,7 @@
+FROM totara/docker-dev-php83:latest
+
+RUN pecl install -f xdebug-3.3.0alpha3 && docker-php-ext-enable xdebug.so
+RUN pecl install -f pcov && docker-php-ext-enable pcov.so
+
+RUN echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
+    && echo "xdebug.start_with_request=trigger" >> /usr/local/etc/php/conf.d/xdebug.ini

--- a/php/php83/Dockerfile
+++ b/php/php83/Dockerfile
@@ -1,0 +1,117 @@
+FROM php:8.3-rc-fpm-bullseye
+
+ARG TIME_ZONE=Pacific/Auckland
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        apt-transport-https \
+        libfreetype6-dev \
+        libjpeg62-turbo-dev \
+        libmcrypt-dev \
+        libpng-dev \
+        libxml2-dev \
+        libicu-dev \
+        libpq-dev \
+        gnupg2 \
+        nano \
+        vim \
+        wget \
+        openssl \
+        locales \
+        tzdata \
+        git \
+        libzip-dev \
+        libmemcached-dev \
+        zip \
+        netcat \
+        bc \
+        ghostscript \
+        graphviz \
+        aspell \
+        libldap2-dev \
+        libltdl-dev \
+    && docker-php-ext-install -j$(nproc) \
+        zip \
+        intl \
+        soap \
+        opcache \
+        pdo_pgsql \
+        pdo_mysql \
+        pgsql \
+        mysqli \
+        exif \
+        ldap \
+    && docker-php-ext-configure gd \
+            --with-freetype \
+            --with-jpeg \
+    && docker-php-ext-install -j$(nproc) gd
+
+RUN git clone https://github.com/tideways/php-profiler-extension.git \
+    && cd php-profiler-extension \
+    && phpize \
+    && ./configure \
+    && make && make install
+
+RUN echo "extension=tideways_xhprof.so" >> /usr/local/etc/php/conf.d/tideways_xhprof.ini
+
+RUN pecl install -o -f redis \
+    &&  rm -rf /tmp/pear \
+    &&  docker-php-ext-enable redis
+
+RUN pecl install -o -f igbinary \
+    &&  rm -rf /tmp/pear \
+    &&  docker-php-ext-enable igbinary
+
+RUN pecl install -o -f memcached \
+    &&  rm -rf /tmp/pear \
+    &&  docker-php-ext-enable memcached
+
+# we need en_US locales for MSSQL connection to work
+# we need en_AU locales for behat to work
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    sed -i -e 's/# en_AU.UTF-8 UTF-8/en_AU.UTF-8 UTF-8/' /etc/locale.gen && \
+    dpkg-reconfigure --frontend=noninteractive locales && \
+    update-locale LANG=en_US.UTF-8
+
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
+
+# install mssql extension
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
+    && curl https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list \
+    && apt-get update && ACCEPT_EULA=Y apt-get install -y \
+    msodbcsql18 \
+    mssql-tools18 \
+    unixodbc-dev
+
+RUN echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bash_profile \
+    && echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc
+
+# Workaround applied: https://github.com/microsoft/msphpsql/issues/1438#issuecomment-1444773949
+RUN pear config-set php_ini `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"` system \
+    && pecl install sqlsrv-5.10.1 pdo_sqlsrv-5.10.1 || \
+    apt-get install -y --allow-downgrades odbcinst=2.3.7 odbcinst1debian2=2.3.7 unixodbc=2.3.7 unixodbc-dev=2.3.7 && \
+    pecl install sqlsrv-5.10.1 pdo_sqlsrv-5.10.1
+
+RUN docker-php-ext-enable sqlsrv.so && docker-php-ext-enable pdo_sqlsrv.so
+
+RUN ln -fs /usr/share/zoneinfo/${TIME_ZONE} /etc/localtime \
+    && dpkg-reconfigure --frontend noninteractive tzdata
+
+COPY config/php.ini /usr/local/etc/php/
+COPY config/fpm.conf /usr/local/etc/php-fpm.d/zz-totara.conf
+
+# Source each .sh file found in the /shell/ folder, always source the default_aliases.sh file first
+RUN echo 'if [[ -e "/root/custom_shell/default-aliases.sh" ]] then source "/root/custom_shell/default-aliases.sh"; fi' >> ~/.bashrc && \
+  echo 'for f in /root/custom_shell/*.sh; do [[ "$f" != "/root/custom_shell/default-aliases.sh" && -e "$f" ]] && source "$f"; done;' >> ~/.bashrc
+
+# Have the option of using the oh my zsh shell.
+RUN apt-get update && apt-get install -y zsh
+RUN sh -c "$(curl https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)" --unattended
+RUN git clone https://github.com/romkatv/powerlevel10k ~/.oh-my-zsh/custom/themes/powerlevel10k
+RUN git clone https://github.com/zsh-users/zsh-autosuggestions ~/.oh-my-zsh/custom/plugins/zsh-autosuggestions
+RUN git clone https://github.com/zsh-users/zsh-completions ~/.oh-my-zsh/custom/plugins/zsh-completions
+RUN git clone https://github.com/zsh-users/zsh-syntax-highlighting ~/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting
+RUN echo 'setopt +o nomatch' > ~/.zshrc
+RUN echo 'source ~/custom_shell/.zshrc' >> ~/.zshrc
+RUN cat ~/.bashrc >> ~/.zshrc

--- a/php/php83/config/fpm.conf
+++ b/php/php83/config/fpm.conf
@@ -1,0 +1,2 @@
+[www]
+pm.max_children = 50

--- a/php/php83/config/php.ini
+++ b/php/php83/config/php.ini
@@ -1,0 +1,10 @@
+log_errors = On
+error_log = /dev/stderr
+error_reporting = E_ALL & ~E_DEPRECATED
+max_input_vars=5000
+date.timezone = Pacific/Auckland
+memory_limit=256M
+; necessary as Xdebug impacts performance that hard
+max_execution_time=120
+post_max_size = 64M
+upload_max_filesize = 64M


### PR DESCRIPTION
Created new images for PHP 8.2 and 8.3. Both are based off of regular bullseye and not alpine (we can change them once the WIP alpine PR is good).

8.3 is based on the RC image and we'll update it once 8.3 is released, this is to get ahead on testing things out.

Python is removed from both as it's not needed.