### PR TITLE
Upgrade to Node.js v20 LTS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
   # docker-compose -f docker-compose.yml -f compose/nginx.yml -f compose/pgsql.yml -f compose/php.yml up -d pgsql php-7.3
 
   nodejs:
-    image: node:16
+    image: node:20
     container_name: totara_nodejs
     environment:
       TZ: ${TIME_ZONE}


### PR DESCRIPTION
We're moving to v20 as our minimum in T19, and v20 can successfully build the frontend for all Totara versions in my testing.