### PR TITLE
Remove deprecated version lines from yml.

### DIFF
--- a/compose/apache.yml
+++ b/compose/apache.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
 
   apache:

--- a/compose/build.yml
+++ b/compose/build.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
 
   apache:

--- a/compose/machine-learning.yml
+++ b/compose/machine-learning.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   ml-service:
     build:

--- a/compose/mariadb.yml
+++ b/compose/mariadb.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
 
   mariadb1011:

--- a/compose/mssql.yml
+++ b/compose/mssql.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
 
   mssql2017:

--- a/compose/mysql.yml
+++ b/compose/mysql.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
 
   mysql8:

--- a/compose/nginx.yml
+++ b/compose/nginx.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
 
   nginx:

--- a/compose/pgsql.yml
+++ b/compose/pgsql.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
 
   pgsql93:

--- a/compose/php.yml
+++ b/compose/php.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
 
   php-5.3:

--- a/compose/selenium.yml
+++ b/compose/selenium.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
 
   selenium-hub:

--- a/compose/sync.yml
+++ b/compose/sync.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
 
   nginx:

--- a/custom/example.yml.dist
+++ b/custom/example.yml.dist
@@ -1,5 +1,4 @@
 # Example compose file override
-version: "3.7"
 
 services:
   nginx:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
 
   # this file only contains a small part of the container definitions


### PR DESCRIPTION
it is a support to avoid getting warnings on the versions in the *.yml files.

Example message from the system:
WARN[0000] /totara-docker-dev/docker-compose.yml: `version` is obsolete 