### PR TITLE
Add defaults settings for pcov library

### DIFF
--- a/php/php71-debug/Dockerfile
+++ b/php/php71-debug/Dockerfile
@@ -5,3 +5,9 @@ RUN pecl install -f pcov && docker-php-ext-enable pcov.so
 
 RUN echo "xdebug.remote_enable=1" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.remote_autostart=0" >> /usr/local/etc/php/conf.d/xdebug.ini
+
+# Set some sensible defaults
+RUN echo "pcov.enabled=1" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
+    && echo "pcov.exclude='~(vendor|tests|node_modules|.git|client|.scannerwork)~'" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
+    && echo "pcov.initial.memory=1073741824" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
+    && echo "pcov.initial.files=30000" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini

--- a/php/php72-debug/Dockerfile
+++ b/php/php72-debug/Dockerfile
@@ -5,3 +5,9 @@ RUN pecl install -f pcov && docker-php-ext-enable pcov.so
 
 RUN echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.start_with_request=trigger" >> /usr/local/etc/php/conf.d/xdebug.ini
+
+# Set some sensible defaults
+RUN echo "pcov.enabled=1" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
+    && echo "pcov.exclude='~(vendor|tests|node_modules|.git|client|.scannerwork)~'" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
+    && echo "pcov.initial.memory=1073741824" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
+    && echo "pcov.initial.files=30000" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini

--- a/php/php73-debug/Dockerfile
+++ b/php/php73-debug/Dockerfile
@@ -5,3 +5,9 @@ RUN pecl install -f pcov && docker-php-ext-enable pcov.so
 
 RUN echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.start_with_request=trigger" >> /usr/local/etc/php/conf.d/xdebug.ini
+
+# Set some sensible defaults
+RUN echo "pcov.enabled=1" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
+    && echo "pcov.exclude='~(vendor|tests|node_modules|.git|client|.scannerwork)~'" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
+    && echo "pcov.initial.memory=1073741824" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
+    && echo "pcov.initial.files=30000" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini

--- a/php/php74-debug/Dockerfile
+++ b/php/php74-debug/Dockerfile
@@ -5,3 +5,9 @@ RUN pecl install -f pcov && docker-php-ext-enable pcov.so
 
 RUN echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.start_with_request=trigger" >> /usr/local/etc/php/conf.d/xdebug.ini
+
+# Set some sensible defaults
+RUN echo "pcov.enabled=1" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
+    && echo "pcov.exclude='~(vendor|tests|node_modules|.git|client|.scannerwork)~'" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
+    && echo "pcov.initial.memory=1073741824" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
+    && echo "pcov.initial.files=30000" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini

--- a/php/php80-debug/Dockerfile
+++ b/php/php80-debug/Dockerfile
@@ -5,3 +5,9 @@ RUN pecl install -f pcov && docker-php-ext-enable pcov.so
 
 RUN echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.start_with_request=trigger" >> /usr/local/etc/php/conf.d/xdebug.ini
+
+# Set some sensible defaults
+RUN echo "pcov.enabled=1" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
+    && echo "pcov.exclude='~(vendor|tests|node_modules|.git|client|.scannerwork)~'" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
+    && echo "pcov.initial.memory=1073741824" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
+    && echo "pcov.initial.files=30000" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini

--- a/php/php81-debug/Dockerfile
+++ b/php/php81-debug/Dockerfile
@@ -5,3 +5,9 @@ RUN pecl install -f pcov && docker-php-ext-enable pcov.so
 
 RUN echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.start_with_request=trigger" >> /usr/local/etc/php/conf.d/xdebug.ini
+
+# Set some sensible defaults
+RUN echo "pcov.enabled=1" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
+    && echo "pcov.exclude='~(vendor|tests|node_modules|.git|client|.scannerwork)~'" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
+    && echo "pcov.initial.memory=1073741824" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
+    && echo "pcov.initial.files=30000" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini

--- a/php/php82-debug/Dockerfile
+++ b/php/php82-debug/Dockerfile
@@ -5,3 +5,9 @@ RUN pecl install -f pcov && docker-php-ext-enable pcov.so
 
 RUN echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.start_with_request=trigger" >> /usr/local/etc/php/conf.d/xdebug.ini
+
+# Set some sensible defaults
+RUN echo "pcov.enabled=1" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
+    && echo "pcov.exclude='~(vendor|tests|node_modules|.git|client|.scannerwork)~'" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
+    && echo "pcov.initial.memory=1073741824" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
+    && echo "pcov.initial.files=30000" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini

--- a/php/php83-debug/Dockerfile
+++ b/php/php83-debug/Dockerfile
@@ -5,3 +5,9 @@ RUN pecl install -f pcov && docker-php-ext-enable pcov.so
 
 RUN echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.start_with_request=trigger" >> /usr/local/etc/php/conf.d/xdebug.ini
+
+# Set some sensible defaults
+RUN echo "pcov.enabled=1" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
+    && echo "pcov.exclude='~(vendor|tests|node_modules|.git|client|.scannerwork)~'" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
+    && echo "pcov.initial.memory=1073741824" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
+    && echo "pcov.initial.files=30000" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini


### PR DESCRIPTION
To generate coverage reports pcov needs some settings, it's bet to provide some defaults.

To test build and fire up the debug container with the patch and check that the defaults are there.

Example:
`tbuild php-8.3-debug && tup php-8.3-debug`

Check the settings with `php -i | grep pcov`. It should look like this (directory path might vary depending on where you call this):

```
pcov
pcov.directory => /var/www/totara/src
pcov.exclude => ~(vendor|tests|node_modules|.git|client|.scannerwork)~
pcov.initial.memory => 1073741824 bytes
pcov.initial.files => 30000
```