### PR TITLE
Fix error running bash

### DIFF
--- a/php/base/entrypoint.sh
+++ b/php/base/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Source each .sh file found in the /shell/ folder, always source the default_aliases.sh file first
-echo 'if [[ -e "/root/custom_shell/default-aliases.sh" ]] then source "/root/custom_shell/default-aliases.sh"; fi' >> ~/.bashrc
+echo 'if [[ -e "/root/custom_shell/default-aliases.sh" ]]; then source "/root/custom_shell/default-aliases.sh"; fi' >> ~/.bashrc
 echo 'for f in /root/custom_shell/*.sh; do [[ "$f" != "/root/custom_shell/default-aliases.sh" && -e "$f" ]] && source "$f"; done;' >> ~/.bashrc
 echo 'setopt +o nomatch' > ~/.zshrc
 echo 'source ~/custom_shell/.zshrc' >> ~/.zshrc

--- a/php/php56/Dockerfile
+++ b/php/php56/Dockerfile
@@ -90,7 +90,7 @@ COPY config/php.ini /usr/local/etc/php/php.ini
 COPY config/fpm.conf /usr/local/etc/php-fpm.d/zz-totara.conf
 
 # Source each .sh file found in the /shell/ folder, always source the default_aliases.sh file first
-RUN echo 'if [[ -e "/root/custom_shell/default-aliases.sh" ]] then source "/root/custom_shell/default-aliases.sh"; fi' >> ~/.bashrc && \
+RUN echo 'if [[ -e "/root/custom_shell/default-aliases.sh" ]]; then source "/root/custom_shell/default-aliases.sh"; fi' >> ~/.bashrc && \
   echo 'for f in /root/custom_shell/*.sh; do [[ "$f" != "/root/custom_shell/default-aliases.sh" && -e "$f" ]] && source "$f"; done;' >> ~/.bashrc
 
 # Have the option of using the oh my zsh shell.

--- a/php/php70/Dockerfile
+++ b/php/php70/Dockerfile
@@ -111,7 +111,7 @@ COPY config/php.ini /usr/local/etc/php/
 COPY config/fpm.conf /usr/local/etc/php-fpm.d/zz-totara.conf
 
 # Source each .sh file found in the /shell/ folder, always source the default_aliases.sh file first
-RUN echo 'if [[ -e "/root/custom_shell/default-aliases.sh" ]] then source "/root/custom_shell/default-aliases.sh"; fi' >> ~/.bashrc && \
+RUN echo 'if [[ -e "/root/custom_shell/default-aliases.sh" ]]; then source "/root/custom_shell/default-aliases.sh"; fi' >> ~/.bashrc && \
   echo 'for f in /root/custom_shell/*.sh; do [[ "$f" != "/root/custom_shell/default-aliases.sh" && -e "$f" ]] && source "$f"; done;' >> ~/.bashrc
 
 # Have the option of using the oh my zsh shell.

--- a/php/php71/Dockerfile
+++ b/php/php71/Dockerfile
@@ -103,7 +103,7 @@ COPY config/php.ini /usr/local/etc/php/
 COPY config/fpm.conf /usr/local/etc/php-fpm.d/zz-totara.conf
 
 # Source each .sh file found in the /shell/ folder, always source the default_aliases.sh file first
-RUN echo 'if [[ -e "/root/custom_shell/default-aliases.sh" ]] then source "/root/custom_shell/default-aliases.sh"; fi' >> ~/.bashrc && \
+RUN echo 'if [[ -e "/root/custom_shell/default-aliases.sh" ]]; then source "/root/custom_shell/default-aliases.sh"; fi' >> ~/.bashrc && \
   echo 'for f in /root/custom_shell/*.sh; do [[ "$f" != "/root/custom_shell/default-aliases.sh" && -e "$f" ]] && source "$f"; done;' >> ~/.bashrc
 
 # Have the option of using the oh my zsh shell.

--- a/php/php72/Dockerfile
+++ b/php/php72/Dockerfile
@@ -113,7 +113,7 @@ COPY config/php.ini /usr/local/etc/php/
 COPY config/fpm.conf /usr/local/etc/php-fpm.d/zz-totara.conf
 
 # Source each .sh file found in the /shell/ folder, always source the default_aliases.sh file first
-RUN echo 'if [[ -e "/root/custom_shell/default-aliases.sh" ]] then source "/root/custom_shell/default-aliases.sh"; fi' >> ~/.bashrc && \
+RUN echo 'if [[ -e "/root/custom_shell/default-aliases.sh" ]]; then source "/root/custom_shell/default-aliases.sh"; fi' >> ~/.bashrc && \
   echo 'for f in /root/custom_shell/*.sh; do [[ "$f" != "/root/custom_shell/default-aliases.sh" && -e "$f" ]] && source "$f"; done;' >> ~/.bashrc
 
 # Have the option of using the oh my zsh shell.

--- a/php/php73/Dockerfile
+++ b/php/php73/Dockerfile
@@ -114,7 +114,7 @@ COPY config/php.ini /usr/local/etc/php/
 COPY config/fpm.conf /usr/local/etc/php-fpm.d/zz-totara.conf
 
 # Source each .sh file found in the /shell/ folder, always source the default_aliases.sh file first
-RUN echo 'if [[ -e "/root/custom_shell/default-aliases.sh" ]] then source "/root/custom_shell/default-aliases.sh"; fi' >> ~/.bashrc && \
+RUN echo 'if [[ -e "/root/custom_shell/default-aliases.sh" ]]; then source "/root/custom_shell/default-aliases.sh"; fi' >> ~/.bashrc && \
   echo 'for f in /root/custom_shell/*.sh; do [[ "$f" != "/root/custom_shell/default-aliases.sh" && -e "$f" ]] && source "$f"; done;' >> ~/.bashrc
 
 # Have the option of using the oh my zsh shell.

--- a/php/php74/Dockerfile
+++ b/php/php74/Dockerfile
@@ -109,7 +109,7 @@ COPY config/php.ini /usr/local/etc/php/
 COPY config/fpm.conf /usr/local/etc/php-fpm.d/zz-totara.conf
 
 # Source each .sh file found in the /shell/ folder, always source the default_aliases.sh file first
-RUN echo 'if [[ -e "/root/custom_shell/default-aliases.sh" ]] then source "/root/custom_shell/default-aliases.sh"; fi' >> ~/.bashrc && \
+RUN echo 'if [[ -e "/root/custom_shell/default-aliases.sh" ]]; then source "/root/custom_shell/default-aliases.sh"; fi' >> ~/.bashrc && \
   echo 'for f in /root/custom_shell/*.sh; do [[ "$f" != "/root/custom_shell/default-aliases.sh" && -e "$f" ]] && source "$f"; done;' >> ~/.bashrc
 
 # Have the option of using the oh my zsh shell.

--- a/php/php80/Dockerfile
+++ b/php/php80/Dockerfile
@@ -109,7 +109,7 @@ COPY config/php.ini /usr/local/etc/php/
 COPY config/fpm.conf /usr/local/etc/php-fpm.d/zz-totara.conf
 
 # Source each .sh file found in the /shell/ folder, always source the default_aliases.sh file first
-RUN echo 'if [[ -e "/root/custom_shell/default-aliases.sh" ]] then source "/root/custom_shell/default-aliases.sh"; fi' >> ~/.bashrc && \
+RUN echo 'if [[ -e "/root/custom_shell/default-aliases.sh" ]]; then source "/root/custom_shell/default-aliases.sh"; fi' >> ~/.bashrc && \
   echo 'for f in /root/custom_shell/*.sh; do [[ "$f" != "/root/custom_shell/default-aliases.sh" && -e "$f" ]] && source "$f"; done;' >> ~/.bashrc
 
 # Have the option of using the oh my zsh shell.

--- a/php/php81/Dockerfile
+++ b/php/php81/Dockerfile
@@ -109,7 +109,7 @@ COPY config/php.ini /usr/local/etc/php/
 COPY config/fpm.conf /usr/local/etc/php-fpm.d/zz-totara.conf
 
 # Source each .sh file found in the /shell/ folder, always source the default_aliases.sh file first
-RUN echo 'if [[ -e "/root/custom_shell/default-aliases.sh" ]] then source "/root/custom_shell/default-aliases.sh"; fi' >> ~/.bashrc && \
+RUN echo 'if [[ -e "/root/custom_shell/default-aliases.sh" ]]; then source "/root/custom_shell/default-aliases.sh"; fi' >> ~/.bashrc && \
   echo 'for f in /root/custom_shell/*.sh; do [[ "$f" != "/root/custom_shell/default-aliases.sh" && -e "$f" ]] && source "$f"; done;' >> ~/.bashrc
 
 # Have the option of using the oh my zsh shell.

--- a/php/php82/Dockerfile
+++ b/php/php82/Dockerfile
@@ -102,7 +102,7 @@ COPY config/php.ini /usr/local/etc/php/
 COPY config/fpm.conf /usr/local/etc/php-fpm.d/zz-totara.conf
 
 # Source each .sh file found in the /shell/ folder, always source the default_aliases.sh file first
-RUN echo 'if [[ -e "/root/custom_shell/default-aliases.sh" ]] then source "/root/custom_shell/default-aliases.sh"; fi' >> ~/.bashrc && \
+RUN echo 'if [[ -e "/root/custom_shell/default-aliases.sh" ]]; then source "/root/custom_shell/default-aliases.sh"; fi' >> ~/.bashrc && \
   echo 'for f in /root/custom_shell/*.sh; do [[ "$f" != "/root/custom_shell/default-aliases.sh" && -e "$f" ]] && source "$f"; done;' >> ~/.bashrc
 
 # Have the option of using the oh my zsh shell.

--- a/php/php83/Dockerfile
+++ b/php/php83/Dockerfile
@@ -102,7 +102,7 @@ COPY config/php.ini /usr/local/etc/php/
 COPY config/fpm.conf /usr/local/etc/php-fpm.d/zz-totara.conf
 
 # Source each .sh file found in the /shell/ folder, always source the default_aliases.sh file first
-RUN echo 'if [[ -e "/root/custom_shell/default-aliases.sh" ]] then source "/root/custom_shell/default-aliases.sh"; fi' >> ~/.bashrc && \
+RUN echo 'if [[ -e "/root/custom_shell/default-aliases.sh" ]]; then source "/root/custom_shell/default-aliases.sh"; fi' >> ~/.bashrc && \
   echo 'for f in /root/custom_shell/*.sh; do [[ "$f" != "/root/custom_shell/default-aliases.sh" && -e "$f" ]] && source "$f"; done;' >> ~/.bashrc
 
 # Have the option of using the oh my zsh shell.


### PR DESCRIPTION
Currently running bash (tbash) instead of zsh, you get the following:

```
ls: /root/.bashrc: line 20: syntax error near unexpected token `then'
ls: /root/.bashrc: line 20: `if [[ -e "/root/custom_shell/default-aliases.sh" ]] then source "/root/custom_shell/default-aliases.sh"; fi'
```

It appears bash wants it to be `]]; then` instead of `]] then`.