### PR TITLE
Move to newer xhprof extension repository

### DIFF
--- a/php/php72/Dockerfile
+++ b/php/php72/Dockerfile
@@ -50,13 +50,16 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     && docker-php-ext-install -j$(nproc) gd \
     && rm -rf /var/lib/apt/lists/*
 
-RUN git clone https://github.com/tideways/php-profiler-extension.git \
-    && cd php-profiler-extension \
+RUN git clone https://github.com/longxinH/xhprof.git ./xhprof \
+    && cd xhprof \
+    && git checkout v2.3.10 \
+    && cd extension/ \
     && phpize \
     && ./configure \
     && make && make install
 
-RUN echo "extension=tideways_xhprof.so" >> /usr/local/etc/php/conf.d/tideways_xhprof.ini
+RUN echo "extension=xhprof.so" >> /usr/local/etc/php/conf.d/xhprof.ini \
+    && echo "xhprof.output_dir = /tmp/xhprof" >> /usr/local/etc/php/conf.d/xhprof.ini
 
 RUN pecl install -o -f redis \
     &&  rm -rf /tmp/pear \

--- a/php/php73/Dockerfile
+++ b/php/php73/Dockerfile
@@ -50,13 +50,16 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     && docker-php-ext-install -j$(nproc) gd \
     && rm -rf /var/lib/apt/lists/*
 
-RUN git clone https://github.com/tideways/php-profiler-extension.git \
-    && cd php-profiler-extension \
+RUN git clone https://github.com/longxinH/xhprof.git ./xhprof \
+    && cd xhprof \
+    && git checkout v2.3.10 \
+    && cd extension/ \
     && phpize \
     && ./configure \
     && make && make install
 
-RUN echo "extension=tideways_xhprof.so" >> /usr/local/etc/php/conf.d/tideways_xhprof.ini
+RUN echo "extension=xhprof.so" >> /usr/local/etc/php/conf.d/xhprof.ini \
+    && echo "xhprof.output_dir = /tmp/xhprof" >> /usr/local/etc/php/conf.d/xhprof.ini
 
 RUN pecl install -o -f redis \
     &&  rm -rf /tmp/pear \

--- a/php/php74/Dockerfile
+++ b/php/php74/Dockerfile
@@ -45,13 +45,16 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
             --with-jpeg \
     && docker-php-ext-install -j$(nproc) gd
 
-RUN git clone https://github.com/tideways/php-profiler-extension.git \
-    && cd php-profiler-extension \
+RUN git clone https://github.com/longxinH/xhprof.git ./xhprof \
+    && cd xhprof \
+    && git checkout v2.3.10 \
+    && cd extension/ \
     && phpize \
     && ./configure \
     && make && make install
 
-RUN echo "extension=tideways_xhprof.so" >> /usr/local/etc/php/conf.d/tideways_xhprof.ini
+RUN echo "extension=xhprof.so" >> /usr/local/etc/php/conf.d/xhprof.ini \
+    && echo "xhprof.output_dir = /tmp/xhprof" >> /usr/local/etc/php/conf.d/xhprof.ini
 
 RUN pecl install -o -f redis \
     &&  rm -rf /tmp/pear \

--- a/php/php80/Dockerfile
+++ b/php/php80/Dockerfile
@@ -45,13 +45,16 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
             --with-jpeg \
     && docker-php-ext-install -j$(nproc) gd
 
-RUN git clone https://github.com/tideways/php-profiler-extension.git \
-    && cd php-profiler-extension \
+RUN git clone https://github.com/longxinH/xhprof.git ./xhprof \
+    && cd xhprof \
+    && git checkout v2.3.10 \
+    && cd extension/ \
     && phpize \
     && ./configure \
     && make && make install
 
-RUN echo "extension=tideways_xhprof.so" >> /usr/local/etc/php/conf.d/tideways_xhprof.ini
+RUN echo "extension=xhprof.so" >> /usr/local/etc/php/conf.d/xhprof.ini \
+    && echo "xhprof.output_dir = /tmp/xhprof" >> /usr/local/etc/php/conf.d/xhprof.ini
 
 RUN pecl install -o -f redis \
     &&  rm -rf /tmp/pear \

--- a/php/php81/Dockerfile
+++ b/php/php81/Dockerfile
@@ -45,13 +45,16 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
             --with-jpeg \
     && docker-php-ext-install -j$(nproc) gd
 
-RUN git clone https://github.com/tideways/php-profiler-extension.git \
-    && cd php-profiler-extension \
+RUN git clone https://github.com/longxinH/xhprof.git ./xhprof \
+    && cd xhprof \
+    && git checkout v2.3.10 \
+    && cd extension/ \
     && phpize \
     && ./configure \
     && make && make install
 
-RUN echo "extension=tideways_xhprof.so" >> /usr/local/etc/php/conf.d/tideways_xhprof.ini
+RUN echo "extension=xhprof.so" >> /usr/local/etc/php/conf.d/xhprof.ini \
+    && echo "xhprof.output_dir = /tmp/xhprof" >> /usr/local/etc/php/conf.d/xhprof.ini
 
 RUN pecl install -o -f redis \
     &&  rm -rf /tmp/pear \

--- a/php/php82/Dockerfile
+++ b/php/php82/Dockerfile
@@ -45,13 +45,16 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
             --with-jpeg \
     && docker-php-ext-install -j$(nproc) gd
 
-RUN git clone https://github.com/tideways/php-profiler-extension.git \
-    && cd php-profiler-extension \
+RUN git clone https://github.com/longxinH/xhprof.git ./xhprof \
+    && cd xhprof \
+    && git checkout v2.3.10 \
+    && cd extension/ \
     && phpize \
     && ./configure \
     && make && make install
 
-RUN echo "extension=tideways_xhprof.so" >> /usr/local/etc/php/conf.d/tideways_xhprof.ini
+RUN echo "extension=xhprof.so" >> /usr/local/etc/php/conf.d/xhprof.ini \
+    && echo "xhprof.output_dir = /tmp/xhprof" >> /usr/local/etc/php/conf.d/xhprof.ini
 
 RUN pecl install -o -f redis \
     &&  rm -rf /tmp/pear \

--- a/php/php83/Dockerfile
+++ b/php/php83/Dockerfile
@@ -45,13 +45,16 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
             --with-jpeg \
     && docker-php-ext-install -j$(nproc) gd
 
-RUN git clone https://github.com/tideways/php-profiler-extension.git \
-    && cd php-profiler-extension \
+RUN git clone https://github.com/longxinH/xhprof.git ./xhprof \
+    && cd xhprof \
+    && git checkout v2.3.10 \
+    && cd extension/ \
     && phpize \
     && ./configure \
     && make && make install
 
-RUN echo "extension=tideways_xhprof.so" >> /usr/local/etc/php/conf.d/tideways_xhprof.ini
+RUN echo "extension=xhprof.so" >> /usr/local/etc/php/conf.d/xhprof.ini \
+    && echo "xhprof.output_dir = /tmp/xhprof" >> /usr/local/etc/php/conf.d/xhprof.ini
 
 RUN pecl install -o -f redis \
     &&  rm -rf /tmp/pear \


### PR DESCRIPTION
The github repository for the tideways/xhprof extension used has been superseded by https://github.com/longxinH/xhprof which is now actively maintained.

This patch updates the Dockerfiles to use the new repo.

### How to test

1. Check out this patch (Follow [these guidelines](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally))
2. Run `tbuild php-7.2 && tup php-7.2`
3. The build should be successful
4. Try to profile something