### PR TITLE
Fix debug container memory usage and slow xdebug performance

### DIFF
--- a/php/php71-debug/Dockerfile
+++ b/php/php71-debug/Dockerfile
@@ -9,5 +9,7 @@ RUN echo "xdebug.remote_enable=1" >> /usr/local/etc/php/conf.d/xdebug.ini \
 # Set some sensible defaults
 RUN echo "pcov.enabled=1" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
     && echo "pcov.exclude='~(vendor|tests|node_modules|.git|client|.scannerwork)~'" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
-    && echo "pcov.initial.memory=1073741824" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
+    # The next line can be enabled (and applied with tbuild and tup of this container) to optimise memory usage \
+    # Note that PHP's memory limit needs to be high enough.
+    #&& echo "pcov.initial.memory=1073741824" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
     && echo "pcov.initial.files=30000" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini

--- a/php/php72-debug/Dockerfile
+++ b/php/php72-debug/Dockerfile
@@ -9,5 +9,7 @@ RUN echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
 # Set some sensible defaults
 RUN echo "pcov.enabled=1" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
     && echo "pcov.exclude='~(vendor|tests|node_modules|.git|client|.scannerwork)~'" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
-    && echo "pcov.initial.memory=1073741824" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
+    # The next line can be enabled (and applied with tbuild and tup of this container) to optimise memory usage \
+    # Note that PHP's memory limit needs to be high enough.
+    #&& echo "pcov.initial.memory=1073741824" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
     && echo "pcov.initial.files=30000" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini

--- a/php/php73-debug/Dockerfile
+++ b/php/php73-debug/Dockerfile
@@ -9,5 +9,7 @@ RUN echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
 # Set some sensible defaults
 RUN echo "pcov.enabled=1" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
     && echo "pcov.exclude='~(vendor|tests|node_modules|.git|client|.scannerwork)~'" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
-    && echo "pcov.initial.memory=1073741824" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
+    # The next line can be enabled (and applied with tbuild and tup of this container) to optimise memory usage \
+    # Note that PHP's memory limit needs to be high enough.
+    #&& echo "pcov.initial.memory=1073741824" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
     && echo "pcov.initial.files=30000" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini

--- a/php/php74-debug/Dockerfile
+++ b/php/php74-debug/Dockerfile
@@ -9,5 +9,7 @@ RUN echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
 # Set some sensible defaults
 RUN echo "pcov.enabled=1" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
     && echo "pcov.exclude='~(vendor|tests|node_modules|.git|client|.scannerwork)~'" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
-    && echo "pcov.initial.memory=1073741824" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
+    # The next line can be enabled (and applied with tbuild and tup of this container) to optimise memory usage \
+    # Note that PHP's memory limit needs to be high enough.
+    #&& echo "pcov.initial.memory=1073741824" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
     && echo "pcov.initial.files=30000" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini

--- a/php/php80-debug/Dockerfile
+++ b/php/php80-debug/Dockerfile
@@ -1,6 +1,6 @@
 FROM totara/docker-dev-php80:latest
 
-RUN pecl install -f xdebug-3.3.2 && docker-php-ext-enable xdebug.so
+RUN pecl install -f xdebug-3.4.0beta1 && docker-php-ext-enable xdebug.so
 RUN pecl install -f pcov && docker-php-ext-enable pcov.so
 
 RUN echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
@@ -9,5 +9,7 @@ RUN echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
 # Set some sensible defaults
 RUN echo "pcov.enabled=1" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
     && echo "pcov.exclude='~(vendor|tests|node_modules|.git|client|.scannerwork)~'" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
-    && echo "pcov.initial.memory=1073741824" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
+    # The next line can be enabled (and applied with tbuild and tup of this container) to optimise memory usage \
+    # Note that PHP's memory limit needs to be high enough.
+    #&& echo "pcov.initial.memory=1073741824" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
     && echo "pcov.initial.files=30000" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini

--- a/php/php81-debug/Dockerfile
+++ b/php/php81-debug/Dockerfile
@@ -1,6 +1,6 @@
 FROM totara/docker-dev-php81:latest
 
-RUN pecl install -f xdebug-3.3.2 && docker-php-ext-enable xdebug.so
+RUN pecl install -f xdebug-3.4.0beta1 && docker-php-ext-enable xdebug.so
 RUN pecl install -f pcov && docker-php-ext-enable pcov.so
 
 RUN echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
@@ -9,5 +9,7 @@ RUN echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
 # Set some sensible defaults
 RUN echo "pcov.enabled=1" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
     && echo "pcov.exclude='~(vendor|tests|node_modules|.git|client|.scannerwork)~'" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
-    && echo "pcov.initial.memory=1073741824" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
+    # The next line can be enabled (and applied with tbuild and tup of this container) to optimise memory usage \
+    # Note that PHP's memory limit needs to be high enough.
+    #&& echo "pcov.initial.memory=1073741824" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
     && echo "pcov.initial.files=30000" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini

--- a/php/php82-debug/Dockerfile
+++ b/php/php82-debug/Dockerfile
@@ -1,6 +1,6 @@
 FROM totara/docker-dev-php82:latest
 
-RUN pecl install -f xdebug-3.3.2 && docker-php-ext-enable xdebug.so
+RUN pecl install -f xdebug-3.4.0beta1 && docker-php-ext-enable xdebug.so
 RUN pecl install -f pcov && docker-php-ext-enable pcov.so
 
 RUN echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
@@ -9,5 +9,7 @@ RUN echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
 # Set some sensible defaults
 RUN echo "pcov.enabled=1" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
     && echo "pcov.exclude='~(vendor|tests|node_modules|.git|client|.scannerwork)~'" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
-    && echo "pcov.initial.memory=1073741824" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
+    # The next line can be enabled (and applied with tbuild and tup of this container) to optimise memory usage \
+    # Note that PHP's memory limit needs to be high enough.
+    #&& echo "pcov.initial.memory=1073741824" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
     && echo "pcov.initial.files=30000" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini

--- a/php/php83-debug/Dockerfile
+++ b/php/php83-debug/Dockerfile
@@ -1,6 +1,6 @@
 FROM totara/docker-dev-php83:latest
 
-RUN pecl install -f xdebug-3.3.2 && docker-php-ext-enable xdebug.so
+RUN pecl install -f xdebug-3.4.0beta1 && docker-php-ext-enable xdebug.so
 RUN pecl install -f pcov && docker-php-ext-enable pcov.so
 
 RUN echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
@@ -9,5 +9,7 @@ RUN echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
 # Set some sensible defaults
 RUN echo "pcov.enabled=1" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
     && echo "pcov.exclude='~(vendor|tests|node_modules|.git|client|.scannerwork)~'" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
-    && echo "pcov.initial.memory=1073741824" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
+    # The next line can be enabled (and applied with tbuild and tup of this container) to optimise memory usage \
+    # Note that PHP's memory limit needs to be high enough.
+    #&& echo "pcov.initial.memory=1073741824" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
     && echo "pcov.initial.files=30000" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini


### PR DESCRIPTION
Do build and test the images:

1. Check out the changes
2. Run `tbuild php-8.3-debug` (or any of the other versions)
3. After the build run `tup php-8.3-debug` to recreate and start the container=
4. Enable the performance debugging/footer in the config.php 
5. Open a page, e.g. the dashboard after logging in
6. It should load (no memory issues) and it should be fast (within 1-2s), not like 20s.