### PR TITLE
Build images using github actions

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,57 @@
+on:
+  workflow_call:
+    inputs:
+      image:
+        required: true
+        type: string
+      context:
+        required: true
+        type: string
+      dockerfile:
+        required: false
+        type: string
+        default: 'Dockerfile'
+      multiarch:
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  build-image:
+    name: Build ${{ inputs.image }} image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 1
+      - name: Log in to Docker Hub
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96 # v5.6.1
+        with:
+          images: totara/docker-dev-${{ inputs.image }}
+          # Adds tags for 'x.x.x' release version and 'multiarch' if multiarch
+          tags: |
+            type=semver,pattern={{version}}
+            ${{ inputs.multiarch == true && 'type=raw,multiarch' || '' }}
+      - name: Set up QEMU (to support building for both amd64 and arm64)
+        if: ${{ inputs.multiarch == true }}
+        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+        with:
+          platforms: ${{ inputs.multiarch == true && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+      - name: Build and push images
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
+        with:
+          context: ${{ inputs.context }}
+          file: ${{ inputs.context }}/${{ inputs.dockerfile }}
+          push: true
+          platforms: ${{ inputs.multiarch == true && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: Build docker-dev images upon a new release
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  build-apache-image:
+    name: Build Apache image
+    uses: ./.github/workflows/build-image.yml
+    with:
+      image: apache
+      context: ./apache
+    secrets: inherit
+
+  build-nginx-image:
+    name: Build Nginx image
+    uses: ./.github/workflows/build-image.yml
+    with:
+      image: nginx
+      context: ./nginx
+    secrets: inherit
+
+  build-mssql-images:
+    name: Build MSSQL images
+    strategy:
+      matrix:
+        version: [2017, 2019, 2022]
+    uses: ./.github/workflows/build-image.yml
+    with:
+      image: mssql${{ matrix.version }}
+      context: ./mssql
+      dockerfile: ${{ matrix.version }}/Dockerfile
+      multiarch: false # Mssql does not support multiple architectures
+    secrets: inherit
+
+  build-php-images:
+    name: Build PHP base images
+    strategy:
+      matrix:
+        version: [53, 54, 55, 56, 70, 71, 72, 73, 80, 81, 82, 83]
+    uses: ./.github/workflows/build-image.yml
+    with:
+      image: php${{ matrix.version }}
+      context: ./php/php${{ matrix.version }}
+    secrets: inherit
+
+  build-php-debug-images:
+    name: Build PHP debug images
+    needs: build-php-images
+    strategy:
+      matrix:
+        version: [53, 54, 55, 56, 70, 71, 72, 73, 80, 81, 82, 83]
+    uses: ./.github/workflows/build-image.yml
+    with:
+      image: php${{ matrix.version }}-debug
+      context: ./php/php${{ matrix.version }}-debug
+    secrets: inherit
+
+  build-php-cron-images:
+    name: Build PHP cron images
+    needs: build-php-images
+    strategy:
+      matrix:
+        # Note: no cron container for v5.3
+        version: [54, 55, 56, 70, 71, 72, 73, 80, 81, 82, 83]
+    uses: ./.github/workflows/build-image.yml
+    with:
+      image: php${{ matrix.version }}-cron
+      context: ./php/php${{ matrix.version }}-cron
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Release](https://img.shields.io/github/v/release/totara/totara-docker-dev)](../../releases)
 [![Release Date](https://img.shields.io/github/release-date/totara/totara-docker-dev)](../../releases)
-[![Build Status](https://travis-ci.com/totara/totara-docker-dev.svg?branch=master)](https://travis-ci.com/totara/totara-docker-dev)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/totara/totara-docker-dev/release.yml)](../../actions/workflows/release.yml)
 [![Issues](https://img.shields.io/github/issues/totara/totara-docker-dev)](../../issues)
 [![License](https://img.shields.io/github/license/totara/totara-docker-dev)](../../LICENCE)
 


### PR DESCRIPTION
This adds a github action that triggers upon creating a new release that builds all the docker-dev custom containers and pushes them to docker hub via buildx.The action is able to build images with multiple architectures unlike the current setup in docker hub. See an example pipeline run here: https://github.com/markmetcalfe/totara-docker-dev/actions/runs/11928646925

It tags the image with a `latest` tag, a `major.minor.patch` version (e.g. `1.13.2`) and `multiarch` if it is a multiarch container. This will mean it is no longer necessary to have a custom `arm.yml` compose yaml for devs using arm, as they can just use the default tag (`latest`) and it will use the correct image for their arch.

Another benefit of this change is that we can easily move to using a different container repository such as GHCR or Amazon ECR by just changing the login and push step of the action - no custom setup required.

I've tested that the containers built by this work fine - [check out this PR for testing that the images work](https://github.com/markmetcalfe/totara-docker-dev/pull/1) (uses my personal ghcr instead of docker hub)