### PR TITLE
Split PHP image building up

### DIFF
--- a/.github/workflows/build-php-images.yml
+++ b/.github/workflows/build-php-images.yml
@@ -1,0 +1,50 @@
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+      debug:
+        required: false
+        type: boolean
+        default: true
+      cron:
+        required: false
+        type: boolean
+        default: true
+      multiarch:
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  build-php-image:
+    name: Build PHP ${{ inputs.version }} image
+    uses: ./.github/workflows/build-image.yml
+    with:
+      image: php${{ inputs.version }}
+      context: ./php/php${{ inputs.version }}
+      multiarch: ${{ inputs.multiarch }}
+    secrets: inherit
+
+  build-php-debug-image:
+    name: Build PHP ${{ inputs.version }} debug image
+    if: ${{ inputs.debug == true }}
+    needs: build-php-image
+    uses: ./.github/workflows/build-image.yml
+    with:
+      image: php${{ inputs.version }}-debug
+      context: ./php/php${{ inputs.version }}-debug
+      multiarch: ${{ inputs.multiarch }}
+    secrets: inherit
+
+  build-php-cron-image:
+    name: Build cron image
+    if: ${{ inputs.cron == true }}
+    needs: build-php-image
+    uses: ./.github/workflows/build-image.yml
+    with:
+      image: php${{ inputs.version }}-cron
+      context: ./php/php${{ inputs.version }}-cron
+      multiarch: ${{ inputs.multiarch }}
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,37 +36,35 @@ jobs:
     secrets: inherit
 
   build-php-images:
-    name: Build PHP base images
+    name: Build PHP images
+    uses: ./.github/workflows/build-php-images.yml
     strategy:
+      fail-fast: false
       matrix:
-        version: [53, 54, 55, 56, 70, 71, 72, 73, 80, 81, 82, 83]
-    uses: ./.github/workflows/build-image.yml
+        version: [73, 74, 80, 81, 82, 83]
     with:
-      image: php${{ matrix.version }}
-      context: ./php/php${{ matrix.version }}
+      version: ${{ matrix.version }}
     secrets: inherit
 
-  build-php-debug-images:
-    name: Build PHP debug images
-    needs: build-php-images
-    strategy:
-      matrix:
-        version: [53, 54, 55, 56, 70, 71, 72, 73, 80, 81, 82, 83]
+  build-legacy-php-base-image:
+    name: Build legacy PHP base image
     uses: ./.github/workflows/build-image.yml
     with:
-      image: php${{ matrix.version }}-debug
-      context: ./php/php${{ matrix.version }}-debug
+      image: php-base
+      context: ./php/base
+      multiarch: false
     secrets: inherit
 
-  build-php-cron-images:
-    name: Build PHP cron images
-    needs: build-php-images
+  build-legacy-php-images:
+    name: Build legacy PHP images
+    needs: build-legacy-php-base-image
+    uses: ./.github/workflows/build-php-images.yml
     strategy:
+      fail-fast: false
       matrix:
-        # Note: no cron container for v5.3
-        version: [54, 55, 56, 70, 71, 72, 73, 80, 81, 82, 83]
-    uses: ./.github/workflows/build-image.yml
+        version: [53, 54, 55, 56, 70, 71, 72]
     with:
-      image: php${{ matrix.version }}-cron
-      context: ./php/php${{ matrix.version }}-cron
+      version: ${{ matrix.version }}
+      cron: ${{ matrix.version != 53 }} # 5.3 doesn't have a cron container
+      multiarch: false
     secrets: inherit


### PR DESCRIPTION
Splits up the building of the PHP images between the multiarch ones (7.3+) and the legacy ones (7.2 and below). This is because the older PHP containers require a base image. I've also added `fail-fast: false` to the build matrix so that containers with build failures don't stop other images from building.