### PR TITLE
Ensure config.php is compatible with our supported PHP versions

### DIFF
--- a/.github/workflows/validate-config.yml
+++ b/.github/workflows/validate-config.yml
@@ -1,0 +1,27 @@
+name: Validate that the example config.php has valid syntax
+
+on:
+  pull_request:
+    paths:
+      - 'config.php'
+
+jobs:
+  validate-config:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 1
+      - name: Set up PHP 8
+        uses: shivammathur/setup-php@c541c155eee45413f5b09a52248675b1a2575231 # v2.31.1
+        with:
+          php-version: 8.3
+      - name: Validate config.php syntax is compatible with PHP 8
+        run: php -l ./config.php
+      - name: Set up PHP 5.3
+        uses: shivammathur/setup-php@c541c155eee45413f5b09a52248675b1a2575231 # v2.31.1
+        with:
+          php-version: 5.3
+      - name: Validate config.php syntax is compatible with PHP 5.3
+        run: php -l ./config.php

--- a/config.php
+++ b/config.php
@@ -136,17 +136,13 @@ $CFG->dboptions = array('dbpersist' => false, 'dbsocket' => false, 'dbport' => '
  * then please contribute what you did back to the docker-dev repository :)
  */
 // Ngrok uses a few different URLs, add if a new one is used
-$ngrok_urls = [
-    'ngrok.io',
-    'ngrok-free.app',
-    'ngrok.app',
-];
+$ngrok_urls = array('ngrok-free.app', 'ngrok.app');
 
 // Depending on the Ngrok version its hostname is stored in different server vars
-$ngrok_server_vars = [
-    $_SERVER['HTTP_X_FORWARDED_HOST'] ?? '',
-    $_SERVER['HTTP_X_ORIGINAL_HOST'] ?? '',
-];
+$ngrok_server_vars = array(
+    $_SERVER['HTTP_X_FORWARDED_HOST'] ?: '',
+    $_SERVER['HTTP_X_ORIGINAL_HOST'] ?: '',
+);
 
 $ngrok_hostname = '';
 foreach ($ngrok_server_vars as $server_var) {


### PR DESCRIPTION
Our example config.php isn't compatible with PHP 5.3, so when someone tries to run a (very) old Totara site, they'll get an error since PHP 5.3 doesn't support the square bracket array syntax. This PR changes the config.php to use the `array()` notation, and adds a CI check to ensure that any future changes to config.php are compatible with both PHP 5.3 and PHP 8