### PR TITLE
Add MailDev container and prefer it over mailcatcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Although this project started as a development environment for Totara Learn it c
  * Microsoft SQL Server ([2017](https://www.microsoft.com/en-us/sql-server/sql-server-2017), [2019](https://www.microsoft.com/en-us/sql-server/sql-server-2019), [2022](https://www.microsoft.com/en-us/sql-server/sql-server-2022))
  * [NodeJS](https://nodejs.org/) for building, developing and testing frontend code
  * A [PHPUnit](https://phpunit.de/) and [Behat](http://behat.org/en/latest/) setup to run tests (including [Selenium](https://www.seleniumhq.org/))
- * A [mailcatcher](https://mailcatcher.me/) instance to view sent emails
+ * A [MailDev](https://github.com/maildev/maildev?tab=readme-ov-file#maildev) instance to view sent emails
  * [Redis](https://redis.io/) for caching and/or session handling
  * [XHProf](https://github.com/tideways/php-xhprof-extension) for profiling
  * [XDebug](https://xdebug.org/) installed, ready for debugging with your favorite IDE

--- a/compose/apache.yml
+++ b/compose/apache.yml
@@ -16,7 +16,7 @@ services:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
     depends_on:
-      - mailcatcher
+      - maildev
     networks:
       totara:
         aliases:

--- a/compose/nginx.yml
+++ b/compose/nginx.yml
@@ -16,7 +16,7 @@ services:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
     depends_on:
-      - mailcatcher
+      - maildev
     networks:
       totara:
         aliases:

--- a/config.php
+++ b/config.php
@@ -484,7 +484,7 @@ if ($development_mode) {
 //////////////////////////////////////////////////////////////////////////
 
 // Redirects any emails sent by the server
-$CFG->smtphosts = 'mailcatcher:25';
+$CFG->smtphosts = 'maildev:1025';
 
 $CFG->passwordpolicy = false;
 $CFG->tool_generator_users_password = '12345';

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,17 @@ services:
       - totara-data:${REMOTE_DATA}
     working_dir: ${REMOTE_SRC}
 
+  maildev:
+    image: maildev/maildev
+    container_name: totara_maildev
+    ports:
+      - "1080:1080"
+    environment:
+      TZ: ${TIME_ZONE}
+    networks:
+      - totara
+
+  # Deprecated - use maildev instead
   mailcatcher:
     image: tophfr/mailcatcher
     container_name: totara_mailcatcher


### PR DESCRIPTION
This formally adds maildev as an email viewer and prefers usage of it over mailcatcher.

The mailcatcher docker image hasn't been updated in five years, and doesn't have an arm version. Maildev is a functionally equivalent alternative which has both an amd64 and arm64 docker image, as well as having more recent updates and has far more stars on github (5k+ vs 80)

This requires a config.php change, so I've left the mailcatcher container in so that it doesn't immediately break people's setups.