### PR TITLE
Ignore owners/permissions when restoring DB snapshot

### DIFF
--- a/bin/tdb
+++ b/bin/tdb
@@ -254,7 +254,7 @@ if [ "$db_type" == 'pgsql' ]; then
         $db_command dropdb -U "$db_user" --if-exists "$db_name"
         $db_command createdb -U "$db_user" -T template1 -E UTF-8 "$db_name"
         if [ "$for_totara_box" == "1" ]; then
-            $db_command pg_restore -d "$db_name" -U "$db_user" "$backup_file_remote" >> /dev/null
+            $db_command pg_restore --no-owner --no-privileges -d "$db_name" -U "$db_user" "$backup_file_remote" >> /dev/null
         else
             $db_command psql -U "$db_user" --dbname "$db_name" -f "$backup_file_remote" >> /dev/null
         fi


### PR DESCRIPTION
Includes the `--no-owners` and `--no-privileges` options for the `pg_restore` line, within `tdb restore`.