### PR TITLE
Allow overriding container restart policy

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -10,6 +10,11 @@ LOCAL_SRC=/your/totara/src/path
 # Note that specifying just 'php' will automatically use the latest version of PHP that the Totara site supports
 DEFAULT_CONTAINERS=nginx,pgsql13,php
 
+# Set the restart policy for containers
+# If set to 'no', containers will only start when you manually start them via `tup`
+# If set to 'unless-stopped', containers will restart upon rebooting/crashing
+RESTART_POLICY=unless-stopped
+
 # set this to your local IP address
 # for mac just use "host.docker.internal"
 # for linux run command "docker run --rm alpine ip -4 route list match 0/0 | cut -d' ' -f3" and use the resulting ip address

--- a/compose/apache.yml
+++ b/compose/apache.yml
@@ -3,6 +3,7 @@ services:
   apache:
     image: totara/docker-dev-apache
     container_name: totara_apache
+    restart: ${RESTART_POLICY:-no}
     environment:
       - TZ=${TIME_ZONE}
       - REMOTE_DATA

--- a/compose/machine-learning.yml
+++ b/compose/machine-learning.yml
@@ -3,6 +3,7 @@ services:
     build:
       context: ${ML_TOTARA_PROJECT:?Set the path to your Totara project}/extensions/ml_service
       target: mlbase
+    restart: ${RESTART_POLICY:-no}
     init: true
     pull_policy: build
     environment:

--- a/compose/mariadb.yml
+++ b/compose/mariadb.yml
@@ -3,6 +3,7 @@ services:
   mariadb1104:
     image: mariadb:11.4
     container_name: totara_mariadb1104
+    restart: ${RESTART_POLICY:-no}
     ports:
       - "3316:3306"
     environment:
@@ -19,6 +20,7 @@ services:
   mariadb1011:
     image: mariadb:10.11
     container_name: totara_mariadb1011
+    restart: ${RESTART_POLICY:-no}
     ports:
       - "3315:3306"
     environment:
@@ -35,6 +37,7 @@ services:
   mariadb108:
     image: mariadb:10.8
     container_name: totara_mariadb108
+    restart: ${RESTART_POLICY:-no}
     ports:
       - "3312:3306"
     environment:
@@ -51,6 +54,7 @@ services:
   mariadb107:
     image: mariadb:10.7
     container_name: totara_mariadb107
+    restart: ${RESTART_POLICY:-no}
     ports:
       - "3311:3306"
     environment:
@@ -67,6 +71,7 @@ services:
   mariadb106:
     image: mariadb:10.6
     container_name: totara_mariadb106
+    restart: ${RESTART_POLICY:-no}
     ports:
       - "3310:3306"
     environment:
@@ -83,6 +88,7 @@ services:
   mariadb105:
     image: mariadb:10.5
     container_name: totara_mariadb105
+    restart: ${RESTART_POLICY:-no}
     ports:
       - "3307:3306"
     environment:
@@ -99,6 +105,7 @@ services:
   mariadb104:
     image: mariadb:10.4
     container_name: totara_mariadb104
+    restart: ${RESTART_POLICY:-no}
     ports:
       - "3309:3306"
     environment:
@@ -115,6 +122,7 @@ services:
   mariadb103:
     image: mariadb:10.3
     container_name: totara_mariadb103
+    restart: ${RESTART_POLICY:-no}
     ports:
       - "3305:3306"
     environment:
@@ -131,6 +139,7 @@ services:
   mariadb102:
     image: mariadb:10.2
     container_name: totara_mariadb102
+    restart: ${RESTART_POLICY:-no}
     ports:
       - "3302:3306"
     environment:

--- a/compose/mssql.yml
+++ b/compose/mssql.yml
@@ -5,6 +5,7 @@ services:
     # Mssql does not support multiple architectures
     platform: linux/amd64
     container_name: totara_mssql
+    restart: ${RESTART_POLICY:-no}
     ports:
       - "1433:1433"
     environment:
@@ -24,6 +25,7 @@ services:
     # Mssql does not support multiple architectures
     platform: linux/amd64
     container_name: totara_mssql2019
+    restart: ${RESTART_POLICY:-no}
     ports:
       - "1419:1433"
     environment:
@@ -43,6 +45,7 @@ services:
     # Mssql does not support multiple architectures
     platform: linux/amd64
     container_name: totara_mssql2022
+    restart: ${RESTART_POLICY:-no}
     ports:
       - "1420:1433"
     environment:

--- a/compose/mysql.yml
+++ b/compose/mysql.yml
@@ -3,6 +3,7 @@ services:
   mysql8:
     image: mysql:8.0
     container_name: totara_mysql8
+    restart: ${RESTART_POLICY:-no}
     ports:
       - "3308:3306"
     environment:
@@ -19,6 +20,7 @@ services:
   mysql84:
     image: mysql:8.4
     container_name: totara_mysql84
+    restart: ${RESTART_POLICY:-no}
     ports:
       - "3309:3306"
     environment:
@@ -37,6 +39,7 @@ services:
     platform: linux/amd64
     image: mysql:5.7
     container_name: totara_mysql57
+    restart: ${RESTART_POLICY:-no}
     ports:
       - "3306:3306"
     environment:

--- a/compose/nginx.yml
+++ b/compose/nginx.yml
@@ -3,6 +3,7 @@ services:
   nginx:
     image: totara/docker-dev-nginx
     container_name: totara_nginx
+    restart: ${RESTART_POLICY:-no}
     environment:
       - TZ=${TIME_ZONE}
       - REMOTE_DATA

--- a/compose/pgsql.yml
+++ b/compose/pgsql.yml
@@ -3,6 +3,7 @@ services:
   pgsql93:
     image: postgres:9.3-alpine
     container_name: totara_pgsql93
+    restart: ${RESTART_POLICY:-no}
     ports:
       - "5493:5432"
     environment:
@@ -21,6 +22,7 @@ services:
   pgsql96:
     image: postgres:9.6-alpine
     container_name: totara_pgsql96
+    restart: ${RESTART_POLICY:-no}
     ports:
       - "5496:5432"
     environment:
@@ -40,6 +42,7 @@ services:
   pgsql10:
     image: postgres:10-alpine
     container_name: totara_pgsql10
+    restart: ${RESTART_POLICY:-no}
     ports:
       - "5410:5432"
     environment:
@@ -58,6 +61,7 @@ services:
   pgsql11:
     image: postgres:11-alpine
     container_name: totara_pgsql11
+    restart: ${RESTART_POLICY:-no}
     ports:
       - "5411:5432"
     environment:
@@ -76,6 +80,7 @@ services:
   pgsql12:
     image: postgres:12-alpine
     container_name: totara_pgsql12
+    restart: ${RESTART_POLICY:-no}
     ports:
       - "5432:5432"
     environment:
@@ -94,6 +99,7 @@ services:
   pgsql13:
     image: postgres:13-alpine
     container_name: totara_pgsql13
+    restart: ${RESTART_POLICY:-no}
     ports:
       - "5442:5432"
     environment:
@@ -113,6 +119,7 @@ services:
   pgsql14:
     image: postgres:14-alpine
     container_name: totara_pgsql14
+    restart: ${RESTART_POLICY:-no}
     ports:
       - "5443:5432"
     environment:
@@ -132,6 +139,7 @@ services:
   pgsql15:
     image: postgres:15-alpine
     container_name: totara_pgsql15
+    restart: ${RESTART_POLICY:-no}
     ports:
       - "5444:5432"
     environment:
@@ -151,6 +159,7 @@ services:
   pgsql16:
     image: postgres:16-alpine
     container_name: totara_pgsql16
+    restart: ${RESTART_POLICY:-no}
     ports:
       - "5445:5432"
     environment:

--- a/compose/php.yml
+++ b/compose/php.yml
@@ -3,6 +3,7 @@ services:
   php-5.3:
     image: totara/docker-dev-php53
     container_name: totara_php53
+    restart: ${RESTART_POLICY:-no}
     working_dir: ${REMOTE_SRC}
     environment:
       CONTAINERNAME: php-5.3
@@ -23,6 +24,7 @@ services:
   php-5.3-debug:
     image: totara/docker-dev-php53-debug
     container_name: totara_php53_debug
+    restart: ${RESTART_POLICY:-no}
     working_dir: ${REMOTE_SRC}
     environment:
       CONTAINERNAME: php-5.3-debug
@@ -43,6 +45,7 @@ services:
   php-5.4:
     image: totara/docker-dev-php54
     container_name: totara_php54
+    restart: ${RESTART_POLICY:-no}
     working_dir: ${REMOTE_SRC}
     environment:
       CONTAINERNAME: php-5.4
@@ -63,6 +66,7 @@ services:
   php-5.4-debug:
     image: totara/docker-dev-php54-debug
     container_name: totara_php54_debug
+    restart: ${RESTART_POLICY:-no}
     working_dir: ${REMOTE_SRC}
     environment:
       CONTAINERNAME: php-5.4-debug
@@ -83,6 +87,7 @@ services:
   php-5.4-cron:
     image: totara/docker-dev-php54-cron
     container_name: totara_php54_cron
+    restart: ${RESTART_POLICY:-no}
     environment:
       TZ: ${TIME_ZONE}
     volumes:
@@ -95,6 +100,7 @@ services:
   php-5.5:
     image: totara/docker-dev-php55
     container_name: totara_php55
+    restart: ${RESTART_POLICY:-no}
     working_dir: ${REMOTE_SRC}
     environment:
       CONTAINERNAME: php-5.5
@@ -115,6 +121,7 @@ services:
   php-5.5-debug:
     image: totara/docker-dev-php55-debug
     container_name: totara_php55_debug
+    restart: ${RESTART_POLICY:-no}
     working_dir: ${REMOTE_SRC}
     environment:
       CONTAINERNAME: php-5.5-debug
@@ -135,6 +142,7 @@ services:
   php-5.5-cron:
     image: totara/docker-dev-php55-cron
     container_name: totara_php55_cron
+    restart: ${RESTART_POLICY:-no}
     environment:
       TZ: ${TIME_ZONE}
     volumes:
@@ -147,6 +155,7 @@ services:
   php-5.6:
     image: totara/docker-dev-php56
     container_name: totara_php56
+    restart: ${RESTART_POLICY:-no}
     working_dir: ${REMOTE_SRC}
     environment:
       CONTAINERNAME: php-5.6
@@ -167,6 +176,7 @@ services:
   php-5.6-debug:
     image: totara/docker-dev-php56-debug
     container_name: totara_php56_debug
+    restart: ${RESTART_POLICY:-no}
     working_dir: ${REMOTE_SRC}
     environment:
       CONTAINERNAME: php-5.6-debug
@@ -187,6 +197,7 @@ services:
   php-5.6-cron:
     image: totara/docker-dev-php56-cron
     container_name: totara_php56_cron
+    restart: ${RESTART_POLICY:-no}
     environment:
       TZ: ${TIME_ZONE}
     volumes:
@@ -199,6 +210,7 @@ services:
   php-7.0:
     image: totara/docker-dev-php70
     container_name: totara_php70
+    restart: ${RESTART_POLICY:-no}
     working_dir: ${REMOTE_SRC}
     environment:
       CONTAINERNAME: php-7.0
@@ -219,6 +231,7 @@ services:
   php-7.0-debug:
     image: totara/docker-dev-php70-debug
     container_name: totara_php70_debug
+    restart: ${RESTART_POLICY:-no}
     working_dir: ${REMOTE_SRC}
     environment:
       CONTAINERNAME: php-7.0-debug
@@ -239,6 +252,7 @@ services:
   php-7.0-cron:
     image: totara/docker-dev-php70-cron
     container_name: totara_php70_cron
+    restart: ${RESTART_POLICY:-no}
     environment:
       TZ: ${TIME_ZONE}
     volumes:
@@ -251,6 +265,7 @@ services:
   php-7.1:
     image: totara/docker-dev-php71
     container_name: totara_php71
+    restart: ${RESTART_POLICY:-no}
     working_dir: ${REMOTE_SRC}
     environment:
       CONTAINERNAME: php-7.1
@@ -271,6 +286,7 @@ services:
   php-7.1-debug:
     image: totara/docker-dev-php71-debug
     container_name: totara_php71_debug
+    restart: ${RESTART_POLICY:-no}
     working_dir: ${REMOTE_SRC}
     environment:
       CONTAINERNAME: php-7.1-debug
@@ -291,6 +307,7 @@ services:
   php-7.1-cron:
     image: totara/docker-dev-php71-cron
     container_name: totara_php71_cron
+    restart: ${RESTART_POLICY:-no}
     environment:
       TZ: ${TIME_ZONE}
     volumes:
@@ -303,6 +320,7 @@ services:
   php-7.2:
     image: totara/docker-dev-php72
     container_name: totara_php72
+    restart: ${RESTART_POLICY:-no}
     working_dir: ${REMOTE_SRC}
     environment:
       CONTAINERNAME: php-7.2
@@ -323,6 +341,7 @@ services:
   php-7.2-debug:
     image: totara/docker-dev-php72-debug
     container_name: totara_php72_debug
+    restart: ${RESTART_POLICY:-no}
     working_dir: ${REMOTE_SRC}
     environment:
       CONTAINERNAME: php-7.2-debug
@@ -344,6 +363,7 @@ services:
   php-7.2-cron:
     image: totara/docker-dev-php72-cron
     container_name: totara_php72_cron
+    restart: ${RESTART_POLICY:-no}
     environment:
       TZ: ${TIME_ZONE}
     volumes:
@@ -356,6 +376,7 @@ services:
   php-7.3:
     image: totara/docker-dev-php73
     container_name: totara_php73
+    restart: ${RESTART_POLICY:-no}
     working_dir: ${REMOTE_SRC}
     environment:
       CONTAINERNAME: php-7.3
@@ -376,6 +397,7 @@ services:
   php-7.3-debug:
     image: totara/docker-dev-php73-debug
     container_name: totara_php73_debug
+    restart: ${RESTART_POLICY:-no}
     working_dir: ${REMOTE_SRC}
     environment:
       CONTAINERNAME: php-7.3-debug
@@ -397,6 +419,7 @@ services:
   php-7.3-cron:
     image: totara/docker-dev-php73-cron
     container_name: totara_php73_cron
+    restart: ${RESTART_POLICY:-no}
     environment:
       TZ: ${TIME_ZONE}
     volumes:
@@ -409,6 +432,7 @@ services:
   php-7.4:
     image: totara/docker-dev-php74
     container_name: totara_php74
+    restart: ${RESTART_POLICY:-no}
     working_dir: ${REMOTE_SRC}
     environment:
       CONTAINERNAME: php-7.4
@@ -429,6 +453,7 @@ services:
   php-7.4-debug:
     image: totara/docker-dev-php74-debug
     container_name: totara_php74_debug
+    restart: ${RESTART_POLICY:-no}
     working_dir: ${REMOTE_SRC}
     environment:
       CONTAINERNAME: php-7.4-debug
@@ -450,6 +475,7 @@ services:
   php-7.4-cron:
     image: totara/docker-dev-php74-cron
     container_name: totara_php74_cron
+    restart: ${RESTART_POLICY:-no}
     environment:
       TZ: ${TIME_ZONE}
     volumes:
@@ -462,6 +488,7 @@ services:
   php-8.0:
     image: totara/docker-dev-php80
     container_name: totara_php80
+    restart: ${RESTART_POLICY:-no}
     working_dir: ${REMOTE_SRC}
     environment:
       CONTAINERNAME: php-8.0
@@ -481,6 +508,7 @@ services:
   php-8.0-debug:
     image: totara/docker-dev-php80-debug
     container_name: totara_php80_debug
+    restart: ${RESTART_POLICY:-no}
     working_dir: ${REMOTE_SRC}
     environment:
       CONTAINERNAME: php-8.0-debug
@@ -502,6 +530,7 @@ services:
   php-8.0-cron:
     image: totara/docker-dev-php80-cron
     container_name: totara_php80_cron
+    restart: ${RESTART_POLICY:-no}
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
@@ -512,6 +541,7 @@ services:
   php-8.1:
     image: totara/docker-dev-php81
     container_name: totara_php81
+    restart: ${RESTART_POLICY:-no}
     working_dir: ${REMOTE_SRC}
     environment:
       CONTAINERNAME: php-8.1
@@ -531,6 +561,7 @@ services:
   php-8.1-cron:
     image: totara/docker-dev-php81-cron
     container_name: totara_php81_cron
+    restart: ${RESTART_POLICY:-no}
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
@@ -541,6 +572,7 @@ services:
   php-8.1-debug:
     image: totara/docker-dev-php81-debug
     container_name: totara_php81_debug
+    restart: ${RESTART_POLICY:-no}
     working_dir: ${REMOTE_SRC}
     environment:
       CONTAINERNAME: php-8.1-debug
@@ -562,6 +594,7 @@ services:
   php-8.2:
     image: totara/docker-dev-php82
     container_name: totara_php82
+    restart: ${RESTART_POLICY:-no}
     working_dir: ${REMOTE_SRC}
     environment:
       CONTAINERNAME: php-8.2
@@ -581,6 +614,7 @@ services:
   php-8.2-cron:
     image: totara/docker-dev-php82-cron
     container_name: totara_php82_cron
+    restart: ${RESTART_POLICY:-no}
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
@@ -591,6 +625,7 @@ services:
   php-8.2-debug:
     image: totara/docker-dev-php82-debug
     container_name: totara_php82_debug
+    restart: ${RESTART_POLICY:-no}
     working_dir: ${REMOTE_SRC}
     environment:
       CONTAINERNAME: php-8.2-debug
@@ -612,6 +647,7 @@ services:
   php-8.3:
     image: totara/docker-dev-php83
     container_name: totara_php83
+    restart: ${RESTART_POLICY:-no}
     working_dir: ${REMOTE_SRC}
     environment:
       CONTAINERNAME: php-8.3
@@ -631,6 +667,7 @@ services:
   php-8.3-cron:
     image: totara/docker-dev-php83-cron
     container_name: totara_php83_cron
+    restart: ${RESTART_POLICY:-no}
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
@@ -641,6 +678,7 @@ services:
   php-8.3-debug:
     image: totara/docker-dev-php83-debug
     container_name: totara_php83_debug
+    restart: ${RESTART_POLICY:-no}
     working_dir: ${REMOTE_SRC}
     environment:
       CONTAINERNAME: php-8.3-debug

--- a/compose/selenium.yml
+++ b/compose/selenium.yml
@@ -3,6 +3,7 @@ services:
   selenium-hub:
     image: selenium/hub:4.5.3
     container_name: totara_seleniumhub
+    restart: ${RESTART_POLICY:-no}
     ports:
       - "4444:4444"
     networks:
@@ -17,6 +18,7 @@ services:
 
   selenium-chrome:
     image: selenium/node-chrome:106.0
+    restart: ${RESTART_POLICY:-no}
     environment:
       - TZ=${TIME_ZONE}
       - HUB_HOST=selenium-hub
@@ -31,6 +33,7 @@ services:
   selenium-chrome-debug:
     image: selenium/standalone-chrome:106.0
     container_name: totara_chrome_standalone_debug
+    restart: ${RESTART_POLICY:-no}
     ports:
       - "5902:5900"
     environment:

--- a/compose/sync.yml
+++ b/compose/sync.yml
@@ -163,6 +163,7 @@ services:
   sync:
     image: alpine:latest
     container_name: totara_sync
+    restart: ${RESTART_POLICY:-no}
     command: tail -f /dev/null
     volumes:
       - totara-www-sync:${REMOTE_SRC}:nocopy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
   nodejs:
     image: node:20
     container_name: totara_nodejs
+    restart: ${RESTART_POLICY:-no}
     environment:
       TZ: ${TIME_ZONE}
     volumes:
@@ -19,6 +20,7 @@ services:
   mailcatcher:
     image: tophfr/mailcatcher
     container_name: totara_mailcatcher
+    restart: ${RESTART_POLICY:-no}
     ports:
       - "8080:80"
     environment:
@@ -28,6 +30,7 @@ services:
 
   redis:
     image: redis
+    restart: ${RESTART_POLICY:-no}
     # activate persistency
     command: "redis-server --appendonly yes"
     environment:
@@ -39,6 +42,7 @@ services:
 
   memcached:
     image: memcached
+    restart: ${RESTART_POLICY:-no}
     environment:
       TZ: ${TIME_ZONE}
     networks:


### PR DESCRIPTION
This adds a new `.env` option of `RESTART_POLICY` which allows overriding whether a container will restart automatically after rebooting or crashing. This is handy as it means you can make it so that you don't need to `tup` your containers everytime you start your computer. This is a backwards compatible change, where it will default to the status quo.
```bash
# Set the restart policy for containers
# If set to 'no', containers will only start when you manually start them via `tup`
# If set to 'unless-stopped', containers will restart upon rebooting/crashing
RESTART_POLICY=unless-stopped
```