### PR TITLE
Upgrade selenium containers to multiarch versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # [![Totara](https://raw.githubusercontent.com/wiki/totara/totara-docker-dev/images/totara-small.png)](https://totaralearning.com) _Totara Docker Dev:_ A Totara Development Environment
 
-[![Release](https://img.shields.io/github/v/release/totara/totara-docker-dev)](../../releases)
-[![Release Date](https://img.shields.io/github/release-date/totara/totara-docker-dev)](../../releases)
+[![Release](https://img.shields.io/github/v/release/totara/totara-docker-dev)](https://github.com/totara/totara-docker-dev/releases)
+[![Release Date](https://img.shields.io/github/release-date/totara/totara-docker-dev)](https://github.com/totara/totara-docker-dev/releases)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/totara/totara-docker-dev/release.yml)](../../actions/workflows/release.yml)
-[![Issues](https://img.shields.io/github/issues/totara/totara-docker-dev)](../../issues)
-[![License](https://img.shields.io/github/license/totara/totara-docker-dev)](../../LICENCE)
+[![Issues](https://img.shields.io/github/issues/totara/totara-docker-dev)](https://github.com/totara/totara-docker-dev/issues)
+[![License](https://img.shields.io/github/license/totara/totara-docker-dev)](LICENCE)
 
 This project aims to provide an easy way to start developing for Totara by providing a Docker setup.
 
-This setup was created and tested extensively on MacOS and Linux. It also works on Windows via WSL2.
+This setup was created and tested extensively on MacOS (Both Intel & Apple Silicon), Linux, and Windows via WSL2.
 
 Although this project started as a development environment for Totara Learn it can be adapted for use in any other PHP project.
 
@@ -31,7 +31,7 @@ Although this project started as a development environment for Totara Learn it c
 
 ## Installation & Usage
 
-**[See the wiki](../../wiki) for detailed documentation on installation and usage.**
+**[See the wiki](https://github.com/totara/totara-docker-dev/wiki) for detailed documentation on installation and usage.**
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Although this project started as a development environment for Totara Learn it c
  * [XHProf](https://github.com/tideways/php-xhprof-extension) for profiling
  * [XDebug](https://xdebug.org/) installed, ready for debugging with your favorite IDE
  * A [Python](https://www.python.org/) instance to run the Totara Machine Learning service
- * Optimised for [Apple Silicon](../../wiki/Apple-Silicon-support)
 
 ## Installation & Usage
 

--- a/compose/selenium.yml
+++ b/compose/selenium.yml
@@ -1,7 +1,7 @@
 services:
 
   selenium-hub:
-    image: selenium/hub:4.5.3
+    image: selenium/hub:4.28.1
     container_name: totara_seleniumhub
     restart: ${RESTART_POLICY:-no}
     ports:
@@ -17,7 +17,7 @@ services:
       - selenium-chrome
 
   selenium-chrome:
-    image: selenium/node-chrome:106.0
+    image: selenium/node-chromium:132.0
     restart: ${RESTART_POLICY:-no}
     environment:
       - TZ=${TIME_ZONE}
@@ -31,7 +31,7 @@ services:
       - totara
 
   selenium-chrome-debug:
-    image: selenium/standalone-chrome:106.0
+    image: selenium/standalone-chromium:132.0
     container_name: totara_chrome_standalone_debug
     restart: ${RESTART_POLICY:-no}
     ports:


### PR DESCRIPTION
There are now official multiarch selenium containers that support both AMD & ARM as per https://www.selenium.dev/blog/2024/multi-arch-images-via-docker-selenium/ 

Note that there are no plans to explicitly have selenium-chrome containers that support arm, instead they are selenium-chromium. These still work for running behat tests fine. This means we don't need to have a custom docker compose file that overrides the base selenium containers with 3rd party containers that are no longer maintained.