### PR TITLE
Allow passing in any args to tngrok

### DIFF
--- a/bin/tngrok
+++ b/bin/tngrok
@@ -7,7 +7,7 @@ source "$project_path/tools/check_for_update.sh"
 
 export $(grep -E -v '^#' $project_path/.env | xargs)
 
-if [ -z $1 ]; then
+if [[ -z "$*" ]]; then
     echo "Helper for using ngrok with your totara site.
 
 Your ngrok directory will need to be added to the PATH variable for it to work.
@@ -21,8 +21,7 @@ Usage Examples:
     exit;
 fi
 
-if [ ! -z $2 ]; then
-    subdomain="-subdomain=$2"
-fi
+site="$1"
+shift
 
-ngrok http $subdomain --host-header=rewrite "https://$1:8443"
+ngrok http --host-header=rewrite "$@" "https://$site:8443"


### PR DESCRIPTION
The instructions for getting `tngrok` working with a permanent URL [as per the wiki no longer work](https://github.com/totara/totara-docker-dev/wiki/Ngrok#permanent-url), it seems like the ngrok arguments have changed at some point and have broken it.

This updates `tngrok` to support passing in any extra arguments, which means that if the arguments change in the future we don't need to update it again (hopefully). This means we can just run `tngrok integration.totara83 --url=my-totara-site.ngrok.app` to get ngrok running with a permanent URL