### PR TITLE
Add warning to update message that containers will be stopped

### DIFF
--- a/tools/check_for_update.sh
+++ b/tools/check_for_update.sh
@@ -57,7 +57,7 @@ if [[ "$current_version_hash" == "$latest_version_hash" ]]; then
     return &> /dev/null || exit
 fi
 
-read -p "There is a newer version of totara-docker-dev available. Would you like to update? [Y/n] " confirm
+read -p "There is a newer version of totara-docker-dev available. Updating will stop all running containers. Would you like to update? [Y/n] " confirm
 if [[ "$confirm" == "y" || "$confirm" == "Y" ]]; then
     source "$project_path/tools/update.sh"
     # Containers have been stopped, so should quit out and not continue running whatever the command was.


### PR DESCRIPTION
Was not clear prior to upgrade that all running containers would be stopped.

Update to upgrade message makes this more obvious:
`"There is a newer version of totara-docker-dev available. Updating will stop all running containers. Would you like to update? [Y/n] "`