### PR TITLE
Setup connection options for SQL Server

### DIFF
--- a/config.php
+++ b/config.php
@@ -118,6 +118,14 @@ if (!is_dir($CFG->dataroot)) {
 $CFG->dblibrary = 'native';
 $CFG->dboptions = array('dbpersist' => false, 'dbsocket' => false, 'dbport' => '');
 
+/**
+ * If using the docker dev SQL Server images, the servers are configured with self issued SSL certs
+ * They can be ignored/trusted for dev environments only.
+ */
+if ($CFG->dbtype == 'sqlsrv' || $CFG->dbtype == 'mssql') {
+    $CFG->dboptions['trustservercertificate'] = true;
+    $CFG->dboptions['encrypt'] = true;
+}
 
 
 //<editor-fold desc="wwwroot Configuration">


### PR DESCRIPTION
The SQL Server images used in docker-dev are configured with self-issued SSL certificates. These aren't secure so the driver/library will reject connections unless you force it to trust the certificate.
Most developers will use the included SQL Server images, so it makes sense to include that configuration in the default config.php