### PR TITLE
Notify that sudo access is required for the set hosts script

### DIFF
--- a/tools/set_hosts.sh
+++ b/tools/set_hosts.sh
@@ -11,8 +11,10 @@ else
   hosts_file="/etc/hosts"
 fi
 
+echo "Sudo access is required to update the hosts file"
+
 if ! sudo touch "$hosts_file" &> /dev/null; then
-  echo -e "\x1B[33m$hosts_file is not writable!\x1B[0m"
+  echo -e "\x1B[33mSudo access denied or the $hosts_file is not writable!\x1B[0m"
   exit
 fi
 


### PR DESCRIPTION
Before this change, when running the set_hosts.sh script, it would just prompt for a password without saying what the password is for. With this change, we show a message saying `Sudo access is required to update the hosts file` to alleviate confusion. 