### PR TITLE
Install PSPell in PHP containers

### DIFF
--- a/php/php81/Dockerfile
+++ b/php/php81/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         aspell \
         libldap2-dev \
         libltdl-dev \
+        libpspell-dev \
     && docker-php-ext-install -j$(nproc) \
         zip \
         intl \
@@ -40,6 +41,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         mysqli \
         exif \
         ldap \
+        pspell \
     && docker-php-ext-configure gd \
             --with-freetype \
             --with-jpeg \

--- a/php/php82/Dockerfile
+++ b/php/php82/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         aspell \
         libldap2-dev \
         libltdl-dev \
+        libpspell-dev \
     && docker-php-ext-install -j$(nproc) \
         zip \
         intl \
@@ -40,6 +41,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         mysqli \
         exif \
         ldap \
+        pspell \
     && docker-php-ext-configure gd \
             --with-freetype \
             --with-jpeg \

--- a/php/php83/Dockerfile
+++ b/php/php83/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         aspell \
         libldap2-dev \
         libltdl-dev \
+        libpspell-dev \
     && docker-php-ext-install -j$(nproc) \
         zip \
         intl \
@@ -40,6 +41,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         mysqli \
         exif \
         ldap \
+        pspell \
     && docker-php-ext-configure gd \
             --with-freetype \
             --with-jpeg \

--- a/php/php84/Dockerfile
+++ b/php/php84/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         libc-client-dev \
         libkrb5-dev \
         libssl-dev \
+        libpspell-dev \
     && docker-php-ext-install -j$(nproc) \
         zip \
         intl \
@@ -44,6 +45,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         mysqli \
         exif \
         ldap \
+        pspell \
     && docker-php-ext-configure gd \
             --with-freetype \
             --with-jpeg \


### PR DESCRIPTION
Add the extension PSPell onto PHP containers that support Totara 19. Optional extension that is required for catalog search suggestions/spell checks. The default comes bundled with the English dictionaries.

Additional documentation is required:

- To check which language dictionaries are installed, run: `aspell dump dicts` in the PHP container. To install additional languages
- Go to: [Available Aspell Dictionaries](https://ftp.gnu.org/gnu/aspell/dict/0index.html) and download the file for the language you want to add.
- Copy the archive and extract it somewhere where the php shell can access (eg: `~/totara-sites/aspell`)
- In the php container shell, browse to that folder
- Run `chmod u+x ./configure`
- Then run the following commands
- `./configure`
- `make`
- `make install`

- Now run `aspell dump dicts` again, the new languages will show