### PR TITLE
Add support for .localhost domains to nginx

### DIFF
--- a/nginx/config/server.conf
+++ b/nginx/config/server.conf
@@ -1,5 +1,5 @@
 # Match any server name with the format sitename.totara73.tld (where tld can be debug / behat)
-server_name ~^(?<sitename>[\w-]+)?(\.)?totara(?<php_main>[0-9])(?<php_sub>[0-9])(\.)?(?<tld>[\w-]+)?$;
+server_name ~^(?<sitename>[\w-]+)?(\.)?totara(?<php_main>[0-9])(?<php_sub>[0-9])(\.)?(?<tld>[\w-]+)?(?:\.localhost)?$;
 
 # Dynamically resolve the php version from version passed throught by the server name
 set $upstream "php-${php_main}.${php_sub}";


### PR DESCRIPTION
This PR adds support for using `.localhost` domains to access your sites without needing to update your hosts file.

This works because all subdomains of `localhost` also resolve to `localhost` / `127.0.0.1`.

E.g. if you would previously access your site as `learn.totara83`, you can now use `learn.totara83.localhost`, `learn.totara83.debug.localhost`, etc in addition.

`learn.totara83.localhost` will still work without this PR, but the debug one won't.