### PR TITLE
Add .localhost domain suffix to tngrok command

### DIFF
--- a/bin/tngrok
+++ b/bin/tngrok
@@ -13,10 +13,10 @@ if [[ -z "$*" ]]; then
 Your ngrok directory will need to be added to the PATH variable for it to work.
 
 Usage Examples:
-  tngrok totara71                              // Creates a tunnel to your totara site for the specified host (if you don't use mutliple sites)
-  tngrok sitename.totara72                     // Creates a tunnel to your totara site called 'sitename' for the specified host (for mutliple sites)
-  tngrok sitename.totara73.debug               // Same as above, but also enables XDebug
-  tngrok sitename.totara74.debug mysubdomain   // Same as above, but the ngrok domain is static and can be accessed at https://mysubdomain.ngrok.io
+  tngrok totara71                                             // Creates a tunnel to your totara site for the specified host (if you don't use mutliple sites)
+  tngrok sitename.totara72                                    // Creates a tunnel to your totara site called 'sitename' for the specified host (for mutliple sites)
+  tngrok sitename.totara73.debug                              // Same as above, but also enables XDebug
+  tngrok sitename.totara74.debug --url=mysubdomain.ngrok.app  // Same as above, but the ngrok domain is static and can be accessed at https://mysubdomain.ngrok.app
 "
     exit;
 fi
@@ -24,4 +24,9 @@ fi
 site="$1"
 shift
 
-ngrok http --host-header=rewrite "$@" "https://$site:8443"
+# Append .localhost domain suffix if it's not specified
+if [[ ! $site == *.localhost ]]; then
+  site="$site.localhost"
+fi
+
+ngrok http --host-header=$site "$@" "https://localhost:8443"


### PR DESCRIPTION
With this change, the `tngrok` command will always point the ngrok domain to `*.localhost`, regardless of whether `.localhost` was included in the command

Testing instructions:
1. Run `tngrok integration.totara83` and make sure you can visit the site and it's forwarding to `https://main.totara82.localhost:8443` 
1. Run `tngrok integration.totara83.localhost` and make sure you can visit the site and it's forwarding to `https://main.totara82.localhost:8443` 