### PR TITLE
Make using a custom terminal font for zsh optional

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -28,6 +28,10 @@ HOST_IP=host.docker.internal
 # Set your preferred shell (used by things like tphp). bash and zsh are available.
 INTERACTIVE_SHELL=zsh
 
+# Set this to 1 to use Nerdfont icons with zsh within the php containers
+# This requires a Nerdfont to be installed in your terminal - see https://www.nerdfonts.com/font-downloads
+USE_ZSH_NERDFONT=0
+
 # Uncomment this to use mutagen on MacOS (to speed up docker volume syncing)
 #USE_MUTAGEN=1
 

--- a/compose/php.yml
+++ b/compose/php.yml
@@ -10,6 +10,7 @@ services:
       TZ: ${TIME_ZONE}
       HIST_FILE: /root/.bash_history
       DISABLE_AUTO_UPDATE: "true" # disables oh-my-zsh update message
+      USE_ZSH_NERDFONT: ${USE_ZSH_NERDFONT}
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
@@ -33,6 +34,7 @@ services:
       PHP_IDE_CONFIG: serverName=totara53
       HIST_FILE: /root/.bash_history
       DISABLE_AUTO_UPDATE: "true" # disables oh-my-zsh update message
+      USE_ZSH_NERDFONT: ${USE_ZSH_NERDFONT}
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
@@ -52,6 +54,7 @@ services:
       TZ: ${TIME_ZONE}
       HIST_FILE: /root/.bash_history
       DISABLE_AUTO_UPDATE: "true" # disables oh-my-zsh update message
+      USE_ZSH_NERDFONT: ${USE_ZSH_NERDFONT}
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
@@ -75,6 +78,7 @@ services:
       PHP_IDE_CONFIG: serverName=totara54
       HIST_FILE: /root/.bash_history
       DISABLE_AUTO_UPDATE: "true" # disables oh-my-zsh update message
+      USE_ZSH_NERDFONT: ${USE_ZSH_NERDFONT}
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
@@ -107,6 +111,7 @@ services:
       TZ: ${TIME_ZONE}
       HIST_FILE: /root/.bash_history
       DISABLE_AUTO_UPDATE: "true" # disables oh-my-zsh update message
+      USE_ZSH_NERDFONT: ${USE_ZSH_NERDFONT}
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
@@ -130,6 +135,7 @@ services:
       PHP_IDE_CONFIG: serverName=totara55
       HIST_FILE: /root/.bash_history
       DISABLE_AUTO_UPDATE: "true" # disables oh-my-zsh update message
+      USE_ZSH_NERDFONT: ${USE_ZSH_NERDFONT}
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
@@ -162,6 +168,7 @@ services:
       TZ: ${TIME_ZONE}
       HIST_FILE: /root/.bash_history
       DISABLE_AUTO_UPDATE: "true" # disables oh-my-zsh update message
+      USE_ZSH_NERDFONT: ${USE_ZSH_NERDFONT}
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
@@ -185,6 +192,7 @@ services:
       PHP_IDE_CONFIG: serverName=totara56
       HIST_FILE: /root/.bash_history
       DISABLE_AUTO_UPDATE: "true" # disables oh-my-zsh update message
+      USE_ZSH_NERDFONT: ${USE_ZSH_NERDFONT}
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
@@ -217,6 +225,7 @@ services:
       TZ: ${TIME_ZONE}
       HIST_FILE: /root/.bash_history
       DISABLE_AUTO_UPDATE: "true" # disables oh-my-zsh update message
+      USE_ZSH_NERDFONT: ${USE_ZSH_NERDFONT}
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
@@ -240,6 +249,7 @@ services:
       PHP_IDE_CONFIG: serverName=totara70
       HIST_FILE: /root/.bash_history
       DISABLE_AUTO_UPDATE: "true" # disables oh-my-zsh update message
+      USE_ZSH_NERDFONT: ${USE_ZSH_NERDFONT}
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
@@ -272,6 +282,7 @@ services:
       TZ: ${TIME_ZONE}
       HIST_FILE: /root/.bash_history
       DISABLE_AUTO_UPDATE: "true" # disables oh-my-zsh update message
+      USE_ZSH_NERDFONT: ${USE_ZSH_NERDFONT}
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
@@ -295,6 +306,7 @@ services:
       PHP_IDE_CONFIG: serverName=totara71
       HIST_FILE: /root/.bash_history
       DISABLE_AUTO_UPDATE: "true" # disables oh-my-zsh update message
+      USE_ZSH_NERDFONT: ${USE_ZSH_NERDFONT}
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
@@ -327,6 +339,7 @@ services:
       TZ: ${TIME_ZONE}
       HIST_FILE: /root/.bash_history
       DISABLE_AUTO_UPDATE: "true" # disables oh-my-zsh update message
+      USE_ZSH_NERDFONT: ${USE_ZSH_NERDFONT}
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
@@ -351,6 +364,7 @@ services:
       PHP_IDE_CONFIG: serverName=totara72
       HIST_FILE: /root/.bash_history
       DISABLE_AUTO_UPDATE: "true" # disables oh-my-zsh update message
+      USE_ZSH_NERDFONT: ${USE_ZSH_NERDFONT}
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
@@ -383,6 +397,7 @@ services:
       TZ: ${TIME_ZONE}
       HIST_FILE: /root/.bash_history
       DISABLE_AUTO_UPDATE: "true" # disables oh-my-zsh update message
+      USE_ZSH_NERDFONT: ${USE_ZSH_NERDFONT}
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
@@ -407,6 +422,7 @@ services:
       PHP_IDE_CONFIG: serverName=totara73
       HIST_FILE: /root/.bash_history
       DISABLE_AUTO_UPDATE: "true" # disables oh-my-zsh update message
+      USE_ZSH_NERDFONT: ${USE_ZSH_NERDFONT}
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
@@ -439,6 +455,7 @@ services:
       TZ: ${TIME_ZONE}
       HIST_FILE: /root/.bash_history
       DISABLE_AUTO_UPDATE: "true" # disables oh-my-zsh update message
+      USE_ZSH_NERDFONT: ${USE_ZSH_NERDFONT}
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
@@ -463,6 +480,7 @@ services:
       PHP_IDE_CONFIG: serverName=totara74
       HIST_FILE: /root/.bash_history
       DISABLE_AUTO_UPDATE: "true" # disables oh-my-zsh update message
+      USE_ZSH_NERDFONT: ${USE_ZSH_NERDFONT}
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
@@ -494,6 +512,7 @@ services:
       CONTAINERNAME: php-8.0
       HIST_FILE: /root/.bash_history
       DISABLE_AUTO_UPDATE: "true" # disables oh-my-zsh update message
+      USE_ZSH_NERDFONT: ${USE_ZSH_NERDFONT}
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
@@ -518,6 +537,7 @@ services:
       PHP_IDE_CONFIG: serverName=totara80
       HIST_FILE: /root/.bash_history
       DISABLE_AUTO_UPDATE: "true" # disables oh-my-zsh update message
+      USE_ZSH_NERDFONT: ${USE_ZSH_NERDFONT}
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
@@ -547,6 +567,7 @@ services:
       CONTAINERNAME: php-8.1
       HIST_FILE: /root/.bash_history
       DISABLE_AUTO_UPDATE: "true" # disables oh-my-zsh update message
+      USE_ZSH_NERDFONT: ${USE_ZSH_NERDFONT}
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
@@ -582,6 +603,7 @@ services:
       PHP_IDE_CONFIG: serverName=totara81
       HIST_FILE: /root/.bash_history
       DISABLE_AUTO_UPDATE: "true" # disables oh-my-zsh update message
+      USE_ZSH_NERDFONT: ${USE_ZSH_NERDFONT}
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
@@ -600,6 +622,7 @@ services:
       CONTAINERNAME: php-8.2
       HIST_FILE: /root/.bash_history
       DISABLE_AUTO_UPDATE: "true" # disables oh-my-zsh update message
+      USE_ZSH_NERDFONT: ${USE_ZSH_NERDFONT}
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
@@ -635,6 +658,7 @@ services:
       PHP_IDE_CONFIG: serverName=totara82
       HIST_FILE: /root/.bash_history
       DISABLE_AUTO_UPDATE: "true" # disables oh-my-zsh update message
+      USE_ZSH_NERDFONT: ${USE_ZSH_NERDFONT}
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
@@ -653,6 +677,7 @@ services:
       CONTAINERNAME: php-8.3
       HIST_FILE: /root/.bash_history
       DISABLE_AUTO_UPDATE: "true" # disables oh-my-zsh update message
+      USE_ZSH_NERDFONT: ${USE_ZSH_NERDFONT}
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
@@ -688,6 +713,7 @@ services:
       PHP_IDE_CONFIG: serverName=totara83
       HIST_FILE: /root/.bash_history
       DISABLE_AUTO_UPDATE: "true" # disables oh-my-zsh update message
+      USE_ZSH_NERDFONT: ${USE_ZSH_NERDFONT}
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
@@ -706,6 +732,7 @@ services:
       CONTAINERNAME: php-8.4
       HIST_FILE: /root/.bash_history
       DISABLE_AUTO_UPDATE: "true" # disables oh-my-zsh update message
+      USE_ZSH_NERDFONT: ${USE_ZSH_NERDFONT}
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
@@ -739,6 +766,7 @@ services:
       PHP_IDE_CONFIG: serverName=totara84
       HIST_FILE: /root/.bash_history
       DISABLE_AUTO_UPDATE: "true" # disables oh-my-zsh update message
+      USE_ZSH_NERDFONT: ${USE_ZSH_NERDFONT}
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}

--- a/shell/.zshrc
+++ b/shell/.zshrc
@@ -14,12 +14,20 @@ plugins=(
 
 source $ZSH/oh-my-zsh.sh
 
-POWERLEVEL9K_MODE='nerdfont-complete'
+if [ "${USE_ZSH_NERDFONT}" = "1" ]; then
+    POWERLEVEL9K_MODE='nerdfont-complete'
+else
+    POWERLEVEL9K_MODE=powerline
+fi
 
 # Shows logo and php version of the container
 zsh_php_container_name(){
-    local phpicon='\ue608'
-    echo -n "${phpicon} ${CONTAINERNAME}"
+    if [ "${USE_ZSH_NERDFONT}" = "1" ]; then
+        local phpicon='\ue608'
+        echo -n "${phpicon} ${CONTAINERNAME}"
+    else
+        echo -n "$CONTAINERNAME"
+    fi
 }
 POWERLEVEL9K_CUSTOM_CONTAINER="zsh_php_container_name"
 POWERLEVEL9K_CUSTOM_CONTAINER_BACKGROUND="103"
@@ -33,8 +41,12 @@ zsh_db_host(){
         print_error 'Incompatible PHP version or invalid config.php!'
         exit
     fi
-    local dbicon='\uf1c0'
-    echo -n "${dbicon} ${dbhost}"
+    if [ "${USE_ZSH_NERDFONT}" = "1" ]; then
+        local dbicon='\uf1c0'
+        echo -n "${dbicon} ${dbhost}"
+    else
+        echo -n "$dbhost";
+    fi
 }
 POWERLEVEL9K_CUSTOM_DB="zsh_db_host"
 POWERLEVEL9K_CUSTOM_DB_BACKGROUND="043"
@@ -43,8 +55,12 @@ POWERLEVEL9K_CUSTOM_DB_FOREGROUND="black"
 # Shows the totara site version if there is a config.php/version.php in the directory.
 zsh_totara_version(){
     is_site_root || exit
-    local totaraicon='\uf829'
-    echo -n "${totaraicon} $(totara_version)"
+    if [ "${USE_ZSH_NERDFONT}" = "1" ]; then
+        local totaraicon='\uf829'
+        echo -n "${totaraicon} $(totara_version)"
+    else
+        echo -n "$(totara_version)"
+    fi
 }
 POWERLEVEL9K_CUSTOM_TOTARA="zsh_totara_version"
 POWERLEVEL9K_CUSTOM_TOTARA_BACKGROUND="106"
@@ -58,7 +74,11 @@ zsh_dir_name(){
     if [[ -z "$dir" ]]; then
         dir="$dirfull";
     fi
-    echo -n "${diricon} ${dir}"
+    if [ "${USE_ZSH_NERDFONT}" = "1" ]; then
+        echo -n "${diricon} ${dir}"
+    else
+        echo -n "${dir}"
+    fi
 }
 POWERLEVEL9K_CUSTOM_DIR="zsh_dir_name"
 POWERLEVEL9K_CUSTOM_DIR_BACKGROUND="031"


### PR DESCRIPTION
At the moment our installation instructions say to install a Nerdfont into your terminal as a requirement for using `tzsh` for the PHP containers. This is overly prescriptive, and instead we should make using custom terminal fonts an opt in rather than requiring everyone to do it. Particularly because within editors such as VS Code and IntelliJ some extra configuration is required to have them display correctly.

Testing instructions:
1. Checkout this PR
2. Run `tup php-8.3` and `tzsh php-8.3` and check that terminal icons are not displayed
3. Add `USE_ZSH_NERDFONT=1` to your `.env`
4. Run `tup php-8.3` and `tzsh php-8.3` and check that terminal icons are displayed
5. Set `USE_ZSH_NERDFONT=0` in your `.env`
6. Run `tup php-8.3` and `tzsh php-8.3` and check that terminal icons are not displayed