### PR TITLE
Adding Postgres17 and MariaDB 11.8 containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Although this project started as a development environment for Totara Learn it c
  * [NGINX](https://nginx.org/) as a webserver
  * [Apache](https://httpd.apache.org/) as a webserver
  * [PHP](http://php.net/) 5.3, 5.4, 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4 to test for different versions
- * [PostgreSQL](https://www.postgresql.org/) (9.3, 9.6, 10, 11, 12, 13, 14, 15, 16), 
- * [MariaDB](https://mariadb.org/) (10.2, 10.3, 10.4, 10.5, 10.6, 10.7, 10.8, 10.11, 11.4), 
+ * [PostgreSQL](https://www.postgresql.org/) (9.3, 9.6, 10, 11, 12, 13, 14, 15, 16, 17), 
+ * [MariaDB](https://mariadb.org/) (10.2, 10.3, 10.4, 10.5, 10.6, 10.7, 10.8, 10.11, 11.4, 11.8), 
  * [MySQL](https://www.mysql.com/) (5.7, 8.0, 8.4), 
  * Microsoft SQL Server ([2017](https://www.microsoft.com/en-us/sql-server/sql-server-2017), [2019](https://www.microsoft.com/en-us/sql-server/sql-server-2019), [2022](https://www.microsoft.com/en-us/sql-server/sql-server-2022))
  * [NodeJS](https://nodejs.org/) for building, developing and testing frontend code

--- a/bin/tdb
+++ b/bin/tdb
@@ -349,12 +349,12 @@ elif [ "$db_type" == 'mysqli' ]; then
 #                MariaDB                 #
 ##########################################
 elif [ "$db_type" == 'mariadb' ]; then
-    if [[ "$db_host" == 'mariadb1104' ]]; then
-        db_maria_cmd="mariadb"
-        db_maria_backup_cmd="mariadb-dump"
-    else
+    if [[ "$db_host" == mariadb10* ]]; then
         db_maria_cmd="mysql"
-        db_maria_backup_cmd="mysqldump"        
+        db_maria_backup_cmd="mysqldump"
+    else
+        db_maria_cmd="mariadb"
+        db_maria_backup_cmd="mariadb-dump"        
     fi
     db_sql_cmd="$db_command $db_maria_cmd -u\"$db_user\" -p\"$db_password\""
 

--- a/compose/mariadb.yml
+++ b/compose/mariadb.yml
@@ -1,5 +1,22 @@
 services:
 
+  mariadb1108:
+    image: mariadb:11.8
+    container_name: totara_mariadb1108
+    restart: ${RESTART_POLICY:-no}
+    ports:
+      - "3317:3306"
+    environment:
+      TZ: ${TIME_ZONE}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PW}
+    volumes:
+      - mariadb1108-data:/var/lib/mysql
+      - ./mariadb:/etc/mysql/conf.d
+    depends_on:
+      - nginx
+    networks:
+      - totara
+
   mariadb1104:
     image: mariadb:11.4
     container_name: totara_mariadb1104
@@ -155,6 +172,7 @@ services:
 
 volumes:
   mariadb-data:
+  mariadb1108-data:
   mariadb1104-data:
   mariadb1011-data:
   mariadb108-data:

--- a/compose/pgsql.yml
+++ b/compose/pgsql.yml
@@ -178,6 +178,26 @@ services:
       - nginx
     networks:
       - totara
+    
+  pgsql17:
+    image: postgres:17-alpine
+    container_name: totara_pgsql17
+    restart: ${RESTART_POLICY:-no}
+    ports:
+      - "5446:5432"
+    environment:
+      TZ: ${TIME_ZONE}
+      PGDATA: /var/lib/postgresql/data/pgdata
+      POSTGRES_HOST_AUTH_METHOD: trust
+    command:
+      postgres -c 'config_file=/etc/postgresql/postgresql.conf'
+    volumes:
+      - ./pgsql/my-postgres.conf:/etc/postgresql/postgresql.conf
+      - pgsql17-data:/var/lib/postgresql/data
+    depends_on:
+      - nginx
+    networks:
+      - totara
 
 volumes:
   pgsql93-data:
@@ -189,3 +209,4 @@ volumes:
   pgsql14-data:
   pgsql15-data:
   pgsql16-data:
+  pgsql17-data:


### PR DESCRIPTION
A minor change was made to the `tdb` command to account for future versions of MariaDB.

Testing instructions:
- Change your `config.php` to the new version of MariaDB or Postgres.
- Add the Database as a data source in IntelliJ/PHPStorm, ensure all schemas are selected.
- Run `tdb recreate`
- Run `tphp install`
- You should be able to view the database either in the UI or though `tdb shell` then `SHOW TABLES;`