### PR TITLE
Search for matching PHP containers from the lowest instead of the highest

### DIFF
--- a/bin/helpers/php_container.php
+++ b/bin/helpers/php_container.php
@@ -20,7 +20,7 @@ $php_container_names = trim((string) shell_exec('docker ps -aaf "name=^totara_ph
 $php_container_names = !empty($php_container_names) ? preg_split('/\s+/', $php_container_names) : array();
 $php_containers_running = array_combine($php_container_ids, $php_container_names);
 asort($php_containers_running);
-$php_containers_running = array_filter(array_reverse($php_containers_running), function ($container_name) {
+$php_containers_running = array_filter($php_containers_running, function ($container_name) {
     return strpos($container_name, 'debug') === false && strpos($container_name, 'cron') === false;
 });
 
@@ -33,7 +33,6 @@ if (empty($php_containers_matches)) {
 }
 $php_containers_available = array_unique($php_containers_matches[1]);
 asort($php_containers_available);
-$php_containers_available = array_reverse($php_containers_available);
 
 // Get the versions to use from the site composer.json (if it exists)
 $matches = array();


### PR DESCRIPTION
It looks at your running containers first (or previously run, it reads from `docker ps -af "name=^totara_php"`) and finds the lowest one that matches the Totara's composer requirements.

If none are running, it'll then loop through all defined PHP versions from low to high until it finds the first matching one, and boots that up.


To test:

- Remove any existing PHP 8.4 image (stop the container, then `docker rm totara_php84` and `docker rm totara_php84_debug`)
- cd into a Totara project
- run `php /path/to/bin/helpers/php_container.php .`
- Check which PHP version it runs


If you have no containers, it'll start the first viable. If you have 8.3 running, then it'll use that, otherwise it'll boot 8.2.
It'll only pick 8.4 if you have that running, and have no 8.2 or 8.3 running.