### PR TITLE
Fix `tdb help` command

### DIFF
--- a/bin/tdb
+++ b/bin/tdb
@@ -62,10 +62,6 @@ action_options=(
     restore
     shell
 )
-if [[ ! " ${action_options[*]} " =~ " ${action} " ]]; then
-  echo -e "\x1B[33mError: Invalid action '${action}'. Must be one of: ${action_options[*]}\x1B[0m"
-  exit 1
-fi
 
 # Print help info
 if [[ -z $action || ! " ${action_options[@]} " =~ " ${action} " ]]; then


### PR DESCRIPTION
Currently if you type `tdb` or `tdb help` with the develop branch checked out, it gives you an unrecognized command error - this is a regression from #343. This fix restores the previous behavior which outputs help info if you input an unknown command or no command at all.