### PR TITLE
Selenium upgrade

### DIFF
--- a/.github/workflows/validate-config.yml
+++ b/.github/workflows/validate-config.yml
@@ -18,10 +18,10 @@ jobs:
         with:
           php-version: 8.3
       - name: Validate config.php syntax is compatible with PHP 8
-        run: php -l ./config.php
-      - name: Set up PHP 5.3
+        run: php -l ./config.php && find ./php/includes -name '*.php' -exec php -l {} +
+      - name: Set up PHP 5.5
         uses: shivammathur/setup-php@c541c155eee45413f5b09a52248675b1a2575231 # v2.31.1
         with:
-          php-version: 5.3
-      - name: Validate config.php syntax is compatible with PHP 5.3
-        run: php -l ./config.php
+          php-version: 5.5
+      - name: Validate config.php syntax is compatible with PHP 5.5
+        run: php -l ./config.php && find ./php/includes -name '*.php' -exec php -l {} +

--- a/compose/php.yml
+++ b/compose/php.yml
@@ -14,6 +14,7 @@ services:
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
+      - ./php/includes:/var/www/totara/includes
       - bash-history:/root/.bash_history
       - zsh-history:/root/.zsh_history
       - ./shell:/root/custom_shell
@@ -38,6 +39,7 @@ services:
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
+      - ./php/includes:/var/www/totara/includes
       - bash-history:/root/.bash_history
       - zsh-history:/root/.zsh_history
       - ./shell:/root/custom_shell
@@ -58,6 +60,7 @@ services:
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
+      - ./php/includes:/var/www/totara/includes
       - bash-history:/root/.bash_history
       - zsh-history:/root/.zsh_history
       - ./shell:/root/custom_shell
@@ -82,6 +85,7 @@ services:
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
+      - ./php/includes:/var/www/totara/includes
       - bash-history:/root/.bash_history
       - zsh-history:/root/.zsh_history
       - ./shell:/root/custom_shell
@@ -97,6 +101,7 @@ services:
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
+      - ./php/includes:/var/www/totara/includes
       - ./cron.d:/etc/cron.d
     networks:
       - totara
@@ -115,6 +120,7 @@ services:
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
+      - ./php/includes:/var/www/totara/includes
       - bash-history:/root/.bash_history
       - zsh-history:/root/.zsh_history
       - ./shell:/root/custom_shell
@@ -139,6 +145,7 @@ services:
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
+      - ./php/includes:/var/www/totara/includes
       - bash-history:/root/.bash_history
       - zsh-history:/root/.zsh_history
       - ./shell:/root/custom_shell
@@ -154,6 +161,7 @@ services:
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
+      - ./php/includes:/var/www/totara/includes
       - ./cron.d:/etc/cron.d
     networks:
       - totara
@@ -172,6 +180,7 @@ services:
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
+      - ./php/includes:/var/www/totara/includes
       - bash-history:/root/.bash_history
       - zsh-history:/root/.zsh_history
       - ./shell:/root/custom_shell
@@ -196,6 +205,7 @@ services:
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
+      - ./php/includes:/var/www/totara/includes
       - bash-history:/root/.bash_history
       - zsh-history:/root/.zsh_history
       - ./shell:/root/custom_shell
@@ -211,6 +221,7 @@ services:
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
+      - ./php/includes:/var/www/totara/includes
       - ./cron.d:/etc/cron.d
     networks:
       - totara
@@ -229,6 +240,7 @@ services:
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
+      - ./php/includes:/var/www/totara/includes
       - bash-history:/root/.bash_history
       - zsh-history:/root/.zsh_history
       - ./shell:/root/custom_shell
@@ -253,6 +265,7 @@ services:
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
+      - ./php/includes:/var/www/totara/includes
       - bash-history:/root/.bash_history
       - zsh-history:/root/.zsh_history
       - ./shell:/root/custom_shell
@@ -268,6 +281,7 @@ services:
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
+      - ./php/includes:/var/www/totara/includes
       - ./cron.d:/etc/cron.d
     networks:
       - totara
@@ -286,6 +300,7 @@ services:
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
+      - ./php/includes:/var/www/totara/includes
       - bash-history:/root/.bash_history
       - zsh-history:/root/.zsh_history
       - ./shell:/root/custom_shell
@@ -310,6 +325,7 @@ services:
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
+      - ./php/includes:/var/www/totara/includes
       - bash-history:/root/.bash_history
       - zsh-history:/root/.zsh_history
       - ./shell:/root/custom_shell
@@ -325,6 +341,7 @@ services:
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
+      - ./php/includes:/var/www/totara/includes
       - ./cron.d:/etc/cron.d
     networks:
       - totara
@@ -343,6 +360,7 @@ services:
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
+      - ./php/includes:/var/www/totara/includes
       - bash-history:/root/.bash_history
       - zsh-history:/root/.zsh_history
       - ./shell:/root/custom_shell
@@ -368,6 +386,7 @@ services:
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
+      - ./php/includes:/var/www/totara/includes
       - bash-history:/root/.bash_history
       - zsh-history:/root/.zsh_history
       - ./shell:/root/custom_shell
@@ -383,6 +402,7 @@ services:
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
+      - ./php/includes:/var/www/totara/includes
       - ./cron.d:/etc/cron.d
     networks:
       - totara
@@ -401,6 +421,7 @@ services:
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
+      - ./php/includes:/var/www/totara/includes
       - bash-history:/root/.bash_history
       - zsh-history:/root/.zsh_history
       - ./shell:/root/custom_shell
@@ -426,6 +447,7 @@ services:
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
+      - ./php/includes:/var/www/totara/includes
       - bash-history:/root/.bash_history
       - zsh-history:/root/.zsh_history
       - ./shell:/root/custom_shell
@@ -441,6 +463,7 @@ services:
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
+      - ./php/includes:/var/www/totara/includes
       - ./cron.d:/etc/cron.d
     networks:
       - totara
@@ -459,6 +482,7 @@ services:
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
+      - ./php/includes:/var/www/totara/includes
       - bash-history:/root/.bash_history
       - zsh-history:/root/.zsh_history
       - ./shell:/root/custom_shell
@@ -484,6 +508,7 @@ services:
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
+      - ./php/includes:/var/www/totara/includes
       - bash-history:/root/.bash_history
       - zsh-history:/root/.zsh_history
       - ./shell:/root/custom_shell
@@ -499,6 +524,7 @@ services:
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
+      - ./php/includes:/var/www/totara/includes
       - ./cron.d:/etc/cron.d
     networks:
       - totara
@@ -516,6 +542,7 @@ services:
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
+      - ./php/includes:/var/www/totara/includes
       - bash-history:/root/.bash_history
       - zsh-history:/root/.zsh_history
       - ./shell:/root/custom_shell
@@ -541,6 +568,7 @@ services:
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
+      - ./php/includes:/var/www/totara/includes
       - bash-history:/root/.bash_history
       - zsh-history:/root/.zsh_history
       - ./shell:/root/custom_shell
@@ -554,6 +582,7 @@ services:
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
+      - ./php/includes:/var/www/totara/includes
       - ./cron.d:/etc/cron.d
     networks:
       - totara
@@ -571,6 +600,7 @@ services:
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
+      - ./php/includes:/var/www/totara/includes
       - bash-history:/root/.bash_history
       - zsh-history:/root/.zsh_history
       - ./shell:/root/custom_shell
@@ -586,6 +616,7 @@ services:
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
+      - ./php/includes:/var/www/totara/includes
       - ./cron.d:/etc/cron.d
     networks:
       - totara
@@ -607,6 +638,7 @@ services:
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
+      - ./php/includes:/var/www/totara/includes
       - bash-history:/root/.bash_history
       - zsh-history:/root/.zsh_history
       - ./shell:/root/custom_shell
@@ -626,6 +658,7 @@ services:
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
+      - ./php/includes:/var/www/totara/includes
       - bash-history:/root/.bash_history
       - zsh-history:/root/.zsh_history
       - ./shell:/root/custom_shell
@@ -641,6 +674,7 @@ services:
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
+      - ./php/includes:/var/www/totara/includes
       - ./cron.d:/etc/cron.d
     networks:
       - totara
@@ -662,6 +696,7 @@ services:
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
+      - ./php/includes:/var/www/totara/includes
       - bash-history:/root/.bash_history
       - zsh-history:/root/.zsh_history
       - ./shell:/root/custom_shell
@@ -681,6 +716,7 @@ services:
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
+      - ./php/includes:/var/www/totara/includes
       - bash-history:/root/.bash_history
       - zsh-history:/root/.zsh_history
       - ./shell:/root/custom_shell
@@ -696,6 +732,7 @@ services:
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
+      - ./php/includes:/var/www/totara/includes
       - ./cron.d:/etc/cron.d
     networks:
       - totara
@@ -717,6 +754,7 @@ services:
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
+      - ./php/includes:/var/www/totara/includes
       - bash-history:/root/.bash_history
       - zsh-history:/root/.zsh_history
       - ./shell:/root/custom_shell
@@ -736,6 +774,7 @@ services:
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
+      - ./php/includes:/var/www/totara/includes
       - bash-history:/root/.bash_history
       - zsh-history:/root/.zsh_history
       - ./shell:/root/custom_shell
@@ -750,6 +789,7 @@ services:
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
+      - ./php/includes:/var/www/totara/includes
       - ./cron.d:/etc/cron.d
     networks:
       - totara
@@ -770,6 +810,7 @@ services:
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
+      - ./php/includes:/var/www/totara/includes
       - bash-history:/root/.bash_history
       - zsh-history:/root/.zsh_history
       - ./shell:/root/custom_shell

--- a/compose/selenium.yml
+++ b/compose/selenium.yml
@@ -1,7 +1,9 @@
 services:
 
   selenium-hub:
-    image: selenium/hub:4.5.3
+    image: selenium/hub:4.35.0 # For Totara 19+
+    # image: selenium/hub:4.5.3 # For Totara 18 and older
+    # image: seleniarm/hub:4.5.3-20221025 # For Totara 18 and older (Apple Silicon)
     container_name: totara_seleniumhub
     restart: ${RESTART_POLICY:-no}
     ports:
@@ -17,7 +19,9 @@ services:
       - selenium-chrome
 
   selenium-chrome:
-    image: selenium/node-chrome:106.0
+    image: selenium/node-chromium:126.0 # For Totara 19+
+    # image: selenium/node-chrome:102.0 # For Totara 18 and older
+    # image: seleniarm/node-chromium:102.0 # For Totara 18 and older (Apple Silicon)
     restart: ${RESTART_POLICY:-no}
     environment:
       - TZ=${TIME_ZONE}
@@ -30,9 +34,63 @@ services:
     networks:
       - totara
 
-  selenium-chrome-debug:
-    image: selenium/standalone-chrome:106.0
-    container_name: totara_chrome_standalone_debug
+  # We might want to specify individual ports
+  selenium-chrome-debug-18:
+    image: selenium/standalone-chrome:102.0 # For Totara 18 and older
+    # image: seleniarm/standalone-chromium:102.0 # For Totara 18 and older (Apple Silicon)
+    container_name: totara_chrome_standalone_debug_18
+    restart: ${RESTART_POLICY:-no}
+    ports:
+      - "5902:5900"
+    environment:
+      - TZ=${TIME_ZONE}
+    volumes:
+      - /dev/shm:/dev/shm
+    networks:
+      - totara
+
+  selenium-chrome-debug-19:
+    image: selenium/standalone-chromium:126.0 # For Totara 19+
+    container_name: totara_chrome_standalone_debug_19
+    restart: ${RESTART_POLICY:-no}
+    ports:
+      - "5902:5900"
+    environment:
+      - TZ=${TIME_ZONE}
+    volumes:
+      - /dev/shm:/dev/shm
+    networks:
+      - totara
+
+  selenium-chrome-debug-latest:
+    image: selenium/standalone-chromium:latest # For Totara 19+
+    container_name: totara_chrome_standalone_debug_latest
+    restart: ${RESTART_POLICY:-no}
+    ports:
+      - "5902:5900"
+    environment:
+      - TZ=${TIME_ZONE}
+    volumes:
+      - /dev/shm:/dev/shm
+    networks:
+      - totara
+
+  selenium-edge-debug:
+    image: selenium/standalone-edge:latest # For Totara 19+
+    container_name: totara_edge_standalone_debug
+    restart: ${RESTART_POLICY:-no}
+    ports:
+      - "5902:5900"
+    environment:
+      - TZ=${TIME_ZONE}
+    volumes:
+      - /dev/shm:/dev/shm
+    networks:
+      - totara
+
+  selenium-firefox-debug:
+    image: selenium/standalone-firefox:latest # For Totara 19+
+    container_name: totara_firefox_standalone_debug
     restart: ${RESTART_POLICY:-no}
     ports:
       - "5902:5900"

--- a/php/includes/config-after.php
+++ b/php/includes/config-after.php
@@ -91,10 +91,10 @@ if ($DOCKER_DEV->behat_parallel) {
 }
 
 if ($DOCKER_DEV->major_version > 18) {
-    // Behat config for Totara 19 and higher
+    // New behat profile needed for Totara 19+
     $CFG->behat_profiles['default'] = array(
         'browser' => 'chrome',
-        'wd_host' => "http://$DOCKER_DEV->behat_host:4444/wd/hub",
+        'wd_host' => "http://totara_chrome_standalone_debug_19:4444/wd/hub",
         'capabilities' => array(
             'extra_capabilities' => array(
                 'goog:chromeOptions' => array(
@@ -112,11 +112,58 @@ if ($DOCKER_DEV->major_version > 18) {
             )
         )
     );
+    $CFG->behat_profiles['chrome_latest'] = array(
+        'browser' => 'chrome',
+        'wd_host' => "http://totara_chrome_standalone_debug_latest:4444/wd/hub",
+        'capabilities' => array(
+            'extra_capabilities' => array(
+                'goog:chromeOptions' => array(
+                    'args' => array(
+                        '--disable-background-timer-throttling',
+                        '--disable-backgrounding-occluded-windows'
+                    ),
+                    'excludeSwitches' => array(
+                        'enable-automation'
+                    ),
+                    'prefs' => array(
+                        'credentials_enable_service' => false,
+                    ),
+                )
+            )
+        )
+    );
+    $CFG->behat_profiles['edge'] = array(
+        'browser' => 'edge',
+        'wd_host' => "http://totara_edge_standalone_debug:4444/wd/hub",
+        'capabilities' => array(
+            'extra_capabilities' => array(
+                'ms:edgeOptions' => array(
+                    'args' => array(
+                        '--disable-background-timer-throttling',
+                        '--disable-backgrounding-occluded-windows'
+                    ),
+                    'excludeSwitches' => array(
+                        'enable-automation'
+                    ),
+                    'prefs' => array(
+                        'credentials_enable_service' => false,
+                    ),
+                )
+            )
+        )
+    );
+    $CFG->behat_profiles['firefox'] = array(
+        'browser' => 'firefox',
+        'wd_host' => "http://totara_firefox_standalone_debug:4444/wd/hub",
+        'capabilities' => array(
+            'extra_capabilities' => array(),
+        )
+    );
 } else if ($DOCKER_DEV->major_version >= 10) {
     // Behat config for Totara 10+
     $CFG->behat_profiles['default'] = array(
         'browser' => 'chrome',
-        'wd_host' => "http://$DOCKER_DEV->behat_host:4444/wd/hub",
+        'wd_host' => "http://totara_chrome_standalone_debug_18:4444/wd/hub",
         'capabilities' => array(
             'extra_capabilities' => array(
                 'chromeOptions' => array(

--- a/php/includes/config-after.php
+++ b/php/includes/config-after.php
@@ -1,0 +1,249 @@
+<?php
+
+// This file contains docker-dev specific config settings that will be consistent across all docker dev sites.
+// Changes that are made here impact all docker dev sites.
+
+
+
+// DB Options
+
+/**
+ * You shouldn't really need to change these.
+ */
+$CFG->dblibrary = 'native';
+$CFG->dboptions = array('dbpersist' => false, 'dbsocket' => false, 'dbport' => '');
+
+/**
+ * If using the docker dev SQL Server images, the servers are configured with self issued SSL certs
+ * They can be ignored/trusted for dev environments only.
+ */
+if ($CFG->dbtype == 'sqlsrv' || $CFG->dbtype == 'mssql') {
+    $CFG->dboptions['trustservercertificate'] = true;
+    $CFG->dboptions['encrypt'] = true;
+}
+
+
+// Dynamic Dataroot Creation 
+if (!is_dir($CFG->dataroot)) {
+    @mkdir($CFG->dataroot, $CFG->directorypermissions) && @chgrp($CFG->dataroot, 'www-data') && @chown($CFG->dataroot, 'www-data');
+}
+
+
+
+// PHPUnit Configuration
+
+/**
+ * We use a different PHPUnit dataroot for each different version, otherwise there are warnings about the dataroot not being empty.
+ */
+$CFG->phpunit_dataroot = "/var/www/totara/data/{$DOCKER_DEV->site_name}.{$CFG->dbhost}.{$DOCKER_DEV->major_version}.phpunit";
+if (!is_dir($CFG->phpunit_dataroot)) {
+    @mkdir($CFG->phpunit_dataroot, $CFG->directorypermissions) && @chgrp($CFG->phpunit_dataroot, 'www-data') && @chown($CFG->phpunit_dataroot, 'www-data');
+}
+
+
+// Behat Configuration
+
+
+/**
+ * We use a different behat dataroot for each different version, otherwise as the behat.yml will need to be regenerated everytime.
+ * If the same behat.yml is used across versions, then the tests won't run correctly.
+ */
+$CFG->behat_dataroot = "/var/www/totara/data/{$DOCKER_DEV->site_name}.{$CFG->dbhost}.{$DOCKER_DEV->major_version}.behat";
+if (!is_dir($CFG->behat_dataroot)) {
+    @mkdir($CFG->behat_dataroot, $CFG->directorypermissions) && @chgrp($CFG->behat_dataroot, 'www-data') && @chown($CFG->behat_dataroot, 'www-data');
+}
+
+/**
+ * The wwwroot for behat is the same as the host, but with '.behat' added as a suffix (so 'totara73' becomes 'totara73.behat')
+ * You shouldn't really need to change this.
+ */
+$CFG->behat_wwwroot = 'http://totara' . PHP_MAJOR_VERSION . PHP_MINOR_VERSION . '.behat';
+if ($DOCKER_DEV->is_multi_site) {
+    $CFG->behat_wwwroot .= '/' . $DOCKER_DEV->site_name;
+}
+if ($DOCKER_DEV->has_server_dir) {
+    $CFG->behat_wwwroot .= '/server';
+}
+
+/**
+ * This is where the behat setup get a bit complicated - here we generate the behat config that supports multiple different Totara versions.
+ * You shouldn't need to change this section - but if you find this needs modification to get it working,
+ * then please contribute what you did back to the docker-dev repository :)
+ */
+
+if ($DOCKER_DEV->major_version < 2.9) {
+    // Disable running behat in parallel if the Totara version is too old, or if there isn't enough CPU threads available.
+    $DOCKER_DEV->behat_parallel = false;
+}
+
+if ($DOCKER_DEV->behat_parallel) {
+    $DOCKER_DEV->behat_host = 'selenium-hub';
+
+    for ($i = 1; $i <= $DOCKER_DEV->behat_parallel_count; $i++) {
+        $CFG->behat_parallel_run[] = array(
+            'dbname' => $CFG->behat_dbname,
+            'behat_prefix' => "bh{$i}_",
+            'wd_host' => 'http://selenium-hub:4444/wd/hub'
+        );
+    }
+} else {
+    $DOCKER_DEV->behat_host = 'selenium-chrome-debug';
+}
+
+if ($DOCKER_DEV->major_version > 18) {
+    // Behat config for Totara 19 and higher
+    $CFG->behat_profiles['default'] = array(
+        'browser' => 'chrome',
+        'wd_host' => "http://$DOCKER_DEV->behat_host:4444/wd/hub",
+        'capabilities' => array(
+            'extra_capabilities' => array(
+                'goog:chromeOptions' => array(
+                    'args' => array(
+                        '--disable-background-timer-throttling',
+                        '--disable-backgrounding-occluded-windows'
+                    ),
+                    'excludeSwitches' => array(
+                        'enable-automation'
+                    ),
+                    'prefs' => array(
+                        'credentials_enable_service' => false,
+                    ),
+                )
+            )
+        )
+    );
+} else if ($DOCKER_DEV->major_version >= 10) {
+    // Behat config for Totara 10+
+    $CFG->behat_profiles['default'] = array(
+        'browser' => 'chrome',
+        'wd_host' => "http://$DOCKER_DEV->behat_host:4444/wd/hub",
+        'capabilities' => array(
+            'extra_capabilities' => array(
+                'chromeOptions' => array(
+                    'args' => array(
+                        '--disable-infobars',
+                        '--disable-background-throttling'
+                    ),
+                    'prefs' => array(
+                        'credentials_enable_service' => false,
+                    ),
+                    'w3c' => false,
+                ),
+                'goog:chromeOptions' => array(
+                    'args' => array(
+                        '--disable-infobars',
+                        '--disable-background-throttling',
+                        '--disable-background-timer-throttling',
+                        '--disable-backgrounding-occluded-windows'
+                    ),
+                    'prefs' => array(
+                        'credentials_enable_service' => false,
+                    ),
+                    'w3c' => false,
+                    'excludeSwitches' => array(
+                        'enable-automation'
+                    )
+                )
+            )
+        )
+    );
+} else {
+    // Behat config for Totara 9 and earlier
+    $CFG->behat_config = array(
+        'default' => array(
+            'extensions' => array(
+                'Behat\MinkExtension\Extension' => array(
+                    'browser_name' => 'chrome',
+                    'default_session' => 'selenium2',
+                    'selenium2' => array(
+                        'browser' => 'chrome',
+                        'wd_host' => "http://$DOCKER_DEV->behat_host:4444/wd/hub",
+                        'capabilities' => array(
+                            'version' => '',
+                            'platform' => 'LINUX',
+                        )
+                    )
+                )
+            )
+        )
+    );
+    if ($DOCKER_DEV->behat_parallel) {
+        $CFG->behat_profiles = array(
+            'default' => array(
+                'browser' => 'chrome',
+                'wd_host' => "http://$DOCKER_DEV->behat_host:4444/wd/hub",
+                'capabilities' => array(
+                    'browser' => 'chrome',
+                    'browserVersion' => 'ANY',
+                    'version' => '',
+                    'chrome' => array(
+                        'switches' => array(
+                            '--disable-infobars',
+                            '--disable-background-throttling'
+                        ),
+                        'w3c' => false
+                    )
+                )
+            )
+        );
+    }
+}
+
+
+
+// wwwroot setup
+
+// Matches URL with ngrok.app or ngrok-free.app
+$ngrok_hostname_regex = '/\b(?:ngrok-free\.app|ngrok\.app|ngrok\.pizza)\b/';
+if (!empty($_SERVER['HTTP_X_FORWARDED_HOST']) && preg_match($ngrok_hostname_regex, $_SERVER['HTTP_X_FORWARDED_HOST'])) {
+    // Request came via ngrok
+    $_SERVER['HTTP_HOST'] = $_SERVER['HTTP_X_FORWARDED_HOST'];
+    $CFG->wwwroot = 'https://' . $_SERVER['HTTP_HOST'];
+} else if (!empty($_SERVER['HTTP_X_ORIGINAL_HOST']) && preg_match($ngrok_hostname_regex, $_SERVER['HTTP_X_ORIGINAL_HOST'])) {
+    // Request came via ngrok
+    $_SERVER['HTTP_HOST'] = $_SERVER['HTTP_X_ORIGINAL_HOST'];
+    $CFG->wwwroot = 'https://' . $_SERVER['HTTP_HOST'];
+} else if (!empty($_SERVER['HTTP_HOST']) && !empty($_SERVER['REQUEST_SCHEME'])) {
+    // accessing it locally via the web
+    $CFG->wwwroot = $_SERVER['REQUEST_SCHEME'] . '://';
+
+    $hostname = $_SERVER['HTTP_HOST'];
+    $hostname_parts = explode('.', $hostname);
+    if (end($hostname_parts) === 'behat') {
+        // redirect if using the behat URL
+        $hostname = str_replace('.behat', '', $hostname);
+    }
+    $CFG->wwwroot .= $hostname;
+
+    if ($DOCKER_DEV->is_multi_site && strpos($hostname, $DOCKER_DEV->site_name) === false) {
+        $CFG->wwwroot .= '/' . $DOCKER_DEV->site_name;
+        if ($DOCKER_DEV->has_server_dir) {
+            $CFG->wwwroot .= '/server';
+        }
+    }
+} else {
+    // accessing it via CLI
+    $CFG->wwwroot = 'http://totara' . PHP_MAJOR_VERSION . PHP_MINOR_VERSION;
+    if ($DOCKER_DEV->is_multi_site) {
+        $CFG->wwwroot .= '/' . $DOCKER_DEV->site_name;
+    }
+    if ($DOCKER_DEV->has_server_dir) {
+        $CFG->wwwroot .= '/server';
+    }
+}
+
+
+// Redirect emails sent by the server to the maildev container
+$CFG->smtphosts = 'maildev:1025';
+
+
+// Paths to binaries
+$CFG->py3path = '/usr/bin/python3';
+$CFG->pathtogs = '/usr/bin/gs';
+$CFG->pathtodu = '/usr/bin/du';
+$CFG->aspellpath = '/usr/bin/aspell';
+$CFG->pathtodot = '/usr/bin/dot';
+
+
+// This must be the last thing in the config.
+file_exists($DOCKER_DEV->dir . '/lib/setup.php') && require_once $DOCKER_DEV->dir . '/lib/setup.php';

--- a/php/includes/config-before.php
+++ b/php/includes/config-before.php
@@ -1,0 +1,28 @@
+<?php
+
+// This file contains setup for the $DOCKER_DEV variable, used to build other config settings.
+
+
+// Docker-dev specific variable setup
+$DOCKER_DEV->has_server_dir = file_exists($DOCKER_DEV->dir . '/server/config.php');
+$DOCKER_DEV->is_multi_site = $DOCKER_DEV->dir !== '/var/www/totara/src';
+$DOCKER_DEV->site_name = $DOCKER_DEV->is_multi_site ? basename($DOCKER_DEV->dir) : 'totara';
+
+
+// Required for older versions (T12 and below) and moodle
+if (!$DOCKER_DEV->has_server_dir || !isset($CFG)) {
+    unset($CFG);
+    global $CFG;
+    $CFG = new stdClass();
+}
+
+
+// Get what version of Totara/Moodle is running via regex from the version.php file
+// We can't include the version.php file directly as it may contain undefined constants, which results in a fatal errors in PHP 8+
+$version_file = @file_get_contents($DOCKER_DEV->dir . '/server/version.php') ?: file_get_contents($DOCKER_DEV->dir . '/version.php');
+$totara_version_matches = $moodle_version_matches = array();
+preg_match("/TOTARA->version[\s]*=[\s]*'([^']+)'/", $version_file, $totara_version_matches);
+preg_match("/release[\s]*=[\s]*'([\S]+)[^']+'/", $version_file, $moodle_version_matches);
+$DOCKER_DEV->version = end($totara_version_matches) ?: end($moodle_version_matches);
+$DOCKER_DEV->major_version = preg_replace("/^(\d{2}|[1-8]\.\d|9).+$/", '$1', $DOCKER_DEV->version);
+unset($version_file, $totara_version_matches, $moodle_version_matches);

--- a/shell/default-aliases.sh
+++ b/shell/default-aliases.sh
@@ -244,14 +244,17 @@ behat() {
     cp "$behat_dataroot_yml" "$behat_source_yml"
   fi
 
-  # convert relative path to absolute ones
   local args=()
+
+  # Convert relative paths in args to absolute ones
   for arg in "$@"; do
     if [[ -f "$PWD/$arg" ]]; then
         args+=("$PWD/$arg")
     else
         args+=("$arg")
     fi
+
+    # I'd be tempted to detect the profile argument and start the required container(s) here
   done
 
   # Run the actual command


### PR DESCRIPTION
This is a bit of a WIP in that it is untested, and doesn't handle running behat in parallel.

It will give developers the ability to select which browser (and can be extended to specific version) by utilising the `--profile` or `-p` flag in t19+ for a single threaded run

Supported profiles (defaults to chrome:102.0):
- `chrome_latest`. the latest chromium version (from the selenium/standalone-chromium:latest docker image)
- `edge`. the latest edge version (from the selenium/standalone-edge:latest docker image)
- `firefox`,  the latest firefox version (from the selenium/standalone-firefox:latest docker image)

The final iteration will probably the lock the versions down to a specific version