### PR TITLE
Fix pspell in php-8.4 build

### DIFF
--- a/php/php84/Dockerfile
+++ b/php/php84/Dockerfile
@@ -45,7 +45,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         mysqli \
         exif \
         ldap \
-        pspell \
     && docker-php-ext-configure gd \
             --with-freetype \
             --with-jpeg \
@@ -83,9 +82,15 @@ RUN pecl channel-update pecl.php.net && \
     &&  rm -rf /tmp/pear \
     &&  docker-php-ext-enable imap
 
-RUN pecl install -o -f excimer \
+RUN pecl channel-update pecl.php.net && \
+    pecl install -o -f excimer \
     &&  rm -rf /tmp/pear \
     &&  docker-php-ext-enable excimer
+
+RUN pecl channel-update pecl.php.net && \
+    pecl install -o -f pspell \
+    &&  rm -rf /tmp/pear \
+    &&  docker-php-ext-enable pspell
 
 # we need en_US locales for MSSQL connection to work
 # we need en_AU locales for behat to work


### PR DESCRIPTION
Currently the php-8.4 container fails to build, because pspell isn't a base package in PHP 8.4 onwards, and must be installed separately before being enabled. 

To test this:
1. Check out this PR locally
2. Make sure that `tbuild php-8.4` runs successfully