### PR TITLE
Modify tphp to support running phpunit tests & xdebug

### DIFF
--- a/bin/texec
+++ b/bin/texec
@@ -15,21 +15,27 @@ if [[ -z "$container" ]]; then
     exit 1
 fi
 
-# If just 'php' is specified, then dynamically work out which one to actually use based upon the site composer.json
-if [[ "$container" == "php" ]]; then
+# If just 'php' or 'php-debug' is specified, then dynamically work out which one to actually use based upon the site composer.json
+if [[ "$container" == "php" || "$container" == "php-debug" ]]; then
     if [[ ! -f "$local_path/version.php" ]]; then
         echo "This command must be run from a Totara site directory if 'php' is specified for the container"
         exit 1
     fi
     php_container=($(php "$project_path/bin/helpers/php_container.php" "$local_path"))
-    container=${php_container[0]}
+    if [[ "$container" == "php-debug" ]]; then
+        container="${php_container[0]}-debug"
+    else 
+        container=${php_container[0]}
+    fi
     echo -e "\x1B[2mUsing PHP Container: $container\x1B[0m"
 fi
 
 # If we are bashing into php/apache/nginx, then lets make the shell begin in the remote directory
 extra_args=""
 if [[ "$container" =~ "php" || "$container" =~ "nginx" || "$container" =~ "apache" ]]; then
-    extra_args="-w $remote_path"
+    if [[ -f "$local_path/version.php" ]]; then
+        extra_args="-w $remote_path"
+    fi
 fi
 
 # Quote command to be reused as shell input

--- a/bin/tphp
+++ b/bin/tphp
@@ -7,12 +7,32 @@ set -a; source "$project_path/.env"; set +a
 
 if [[ -z "$1" ]]; then
     $script_path/texec php "${INTERACTIVE_SHELL:-zsh}"
-else
-    # Quote command to be reused as shell input
-    command_str=$(printf " %q" "$@")
-    # Handle being called with a php script instead of a command
-    if [[ $1 == *.php ]]; then
-        command_str="php $command_str"
-    fi
-    $script_path/texec php bash -ic "$command_str"
+    exit
 fi
+
+# If the first arg is 'debug', then use the debug container
+php_container_command="php"
+if [[ "$1" == "debug" ]]; then
+    php_container_command="php-debug"
+    shift
+fi
+
+# Replace local path with remote path in any file path arguments
+# e.g. /User/me/totara-sites/mysite/server/plugin/test.php -> /var/www/totara/src/mysite/server/plugin/test.php
+args=()
+for arg in "$@"; do
+    if [[ "$arg" == "$LOCAL_SRC"* && -e "$arg" ]]; then
+        arg="$REMOTE_SRC${arg#$LOCAL_SRC}"
+    fi
+    args+=("$arg")
+done
+
+# Quote command to be reused as shell input
+command_str=$(printf " %q" "${args[@]}")
+
+# Handle being called with a php script instead of a command
+if [[ $1 == *.php ]]; then
+    command_str="$php_container_command $command_str"
+fi
+
+$script_path/texec $php_container_command bash -ic "$command_str"


### PR DESCRIPTION
This changes the `tphp` and `texec` commands to support specifying `php-debug` as the php container, as well as dynamically changing any full paths specified to be the remote path of the file inside the container.

The intent of this is to easily support PHPUnit extensions in VS Code, which don't have good ways of handling our docker dev setup, so this means we can simply abstract the handling into docker dev itself.

This means that if `tphp debug phpunit /Users/mark/totara-sites/main/server/path/to/test.php` is run, then it will transform it to running `phpunit /var/www/totara/src/main/path/to/test.php` in the `php-8.3-debug` container

To test this:
1. Check out this PR
2. Follow the "Running PHPUnit Tests" and "Debugging via XDebug" section[ in these docs](https://github.com/totara/totara-docker-dev/wiki/Visual-Studio-Code-Integration#running-phpunit-tests)
3. Check that you can run tests in a phpunit file