### PR TITLE
Add composer to php images

### DIFF
--- a/php/php73/Dockerfile
+++ b/php/php73/Dockerfile
@@ -78,6 +78,9 @@ RUN pecl install -o -f pcov \
     &&  rm -rf /tmp/pear \
     &&  docker-php-ext-enable pcov
 
+# Install composer
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
 # we need en_US locales for MSSQL connection to work
 # we need en_AU locales for behat to work
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \

--- a/php/php74/Dockerfile
+++ b/php/php74/Dockerfile
@@ -73,6 +73,9 @@ RUN pecl install -o -f pcov \
     &&  rm -rf /tmp/pear \
     &&  docker-php-ext-enable pcov
 
+# Install composer
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
 # we need en_US locales for MSSQL connection to work
 # we need en_AU locales for behat to work
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \

--- a/php/php80/Dockerfile
+++ b/php/php80/Dockerfile
@@ -73,6 +73,9 @@ RUN pecl install -o -f pcov \
     &&  rm -rf /tmp/pear \
     &&  docker-php-ext-enable pcov
 
+# Install composer
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
 # we need en_US locales for MSSQL connection to work
 # we need en_AU locales for behat to work
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \

--- a/php/php81/Dockerfile
+++ b/php/php81/Dockerfile
@@ -79,6 +79,9 @@ RUN pecl install -o -f pcov \
     &&  rm -rf /tmp/pear \
     &&  docker-php-ext-enable pcov
 
+# Install composer
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
 # we need en_US locales for MSSQL connection to work
 # we need en_AU locales for behat to work
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \

--- a/php/php82/Dockerfile
+++ b/php/php82/Dockerfile
@@ -79,6 +79,9 @@ RUN pecl install -o -f pcov \
     &&  rm -rf /tmp/pear \
     &&  docker-php-ext-enable pcov
 
+# Install composer
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
 # we need en_US locales for MSSQL connection to work
 # we need en_AU locales for behat to work
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \

--- a/php/php83/Dockerfile
+++ b/php/php83/Dockerfile
@@ -79,6 +79,9 @@ RUN pecl install -o -f pcov \
     &&  rm -rf /tmp/pear \
     &&  docker-php-ext-enable pcov
 
+# Install composer
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
 # we need en_US locales for MSSQL connection to work
 # we need en_AU locales for behat to work
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \

--- a/php/php84/Dockerfile
+++ b/php/php84/Dockerfile
@@ -46,7 +46,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         mysqli \
         exif \
         ldap \
-        pspell \
     && docker-php-ext-configure gd \
             --with-freetype \
             --with-jpeg \
@@ -84,11 +83,18 @@ RUN pecl channel-update pecl.php.net && \
     &&  rm -rf /tmp/pear \
     &&  docker-php-ext-enable imap
 
-RUN pecl install -o -f excimer \
+RUN pecl channel-update pecl.php.net && \
+    pecl install -o -f excimer \
     &&  rm -rf /tmp/pear \
     &&  docker-php-ext-enable excimer
 
-RUN pecl install -o -f pcov \
+RUN pecl channel-update pecl.php.net && \
+    pecl install -o -f pspell \
+    &&  rm -rf /tmp/pear \
+    &&  docker-php-ext-enable pspell
+
+RUN pecl channel-update pecl.php.net && \
+    pecl install -o -f pcov \
     &&  rm -rf /tmp/pear \
     &&  docker-php-ext-enable pcov
 

--- a/php/php84/Dockerfile
+++ b/php/php84/Dockerfile
@@ -98,6 +98,9 @@ RUN pecl channel-update pecl.php.net && \
     &&  rm -rf /tmp/pear \
     &&  docker-php-ext-enable pcov
 
+# Install composer
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
 # we need en_US locales for MSSQL connection to work
 # we need en_AU locales for behat to work
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \


### PR DESCRIPTION
This PR adds composer to the PHP 7.3+ containers, and also fixes a build issue with PHP 8.4.

To test this:
1. Check out this PR
1. Run:
    ```bash
    for v in php-7.3 php-7.4 php-8.0 php-8.1 php-8.2 php-8.3 php-8.4; do
        tbuild "$v" && tup "$v" && texec "$v" composer --version
    done
    ```
    and make sure there are no errors