### PR TITLE
Hotfix: Fix php debug image builds

### DIFF
--- a/php/php73-debug/Dockerfile
+++ b/php/php73-debug/Dockerfile
@@ -1,15 +1,6 @@
 FROM totara/docker-dev-php73:latest
 
 RUN pecl install -f xdebug-3.1.6 && docker-php-ext-enable xdebug.so
-RUN pecl install -f pcov && docker-php-ext-enable pcov.so
 
 RUN echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.start_with_request=trigger" >> /usr/local/etc/php/conf.d/xdebug.ini
-
-# Set some sensible defaults
-RUN echo "pcov.enabled=1" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
-    && echo "pcov.exclude='~(vendor|tests|node_modules|.git|client|.scannerwork)~'" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
-    # The next line can be enabled (and applied with tbuild and tup of this container) to optimise memory usage \
-    # Note that PHP's memory limit needs to be high enough.
-    #&& echo "pcov.initial.memory=1073741824" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
-    && echo "pcov.initial.files=30000" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini

--- a/php/php74-debug/Dockerfile
+++ b/php/php74-debug/Dockerfile
@@ -1,15 +1,6 @@
 FROM totara/docker-dev-php74:latest
 
 RUN pecl install -f xdebug-3.1.6 && docker-php-ext-enable xdebug.so
-RUN pecl install -f pcov && docker-php-ext-enable pcov.so
 
 RUN echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.start_with_request=trigger" >> /usr/local/etc/php/conf.d/xdebug.ini
-
-# Set some sensible defaults
-RUN echo "pcov.enabled=1" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
-    && echo "pcov.exclude='~(vendor|tests|node_modules|.git|client|.scannerwork)~'" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
-    # The next line can be enabled (and applied with tbuild and tup of this container) to optimise memory usage \
-    # Note that PHP's memory limit needs to be high enough.
-    #&& echo "pcov.initial.memory=1073741824" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
-    && echo "pcov.initial.files=30000" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini

--- a/php/php80-debug/Dockerfile
+++ b/php/php80-debug/Dockerfile
@@ -1,15 +1,6 @@
 FROM totara/docker-dev-php80:latest
 
 RUN pecl install -f xdebug-3.4.0beta1 && docker-php-ext-enable xdebug.so
-RUN pecl install -f pcov && docker-php-ext-enable pcov.so
 
 RUN echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.start_with_request=trigger" >> /usr/local/etc/php/conf.d/xdebug.ini
-
-# Set some sensible defaults
-RUN echo "pcov.enabled=1" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
-    && echo "pcov.exclude='~(vendor|tests|node_modules|.git|client|.scannerwork)~'" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
-    # The next line can be enabled (and applied with tbuild and tup of this container) to optimise memory usage \
-    # Note that PHP's memory limit needs to be high enough.
-    #&& echo "pcov.initial.memory=1073741824" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
-    && echo "pcov.initial.files=30000" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini

--- a/php/php81-debug/Dockerfile
+++ b/php/php81-debug/Dockerfile
@@ -1,15 +1,6 @@
 FROM totara/docker-dev-php81:latest
 
 RUN pecl install -f xdebug-3.4.0beta1 && docker-php-ext-enable xdebug.so
-RUN pecl install -f pcov && docker-php-ext-enable pcov.so
 
 RUN echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.start_with_request=trigger" >> /usr/local/etc/php/conf.d/xdebug.ini
-
-# Set some sensible defaults
-RUN echo "pcov.enabled=1" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
-    && echo "pcov.exclude='~(vendor|tests|node_modules|.git|client|.scannerwork)~'" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
-    # The next line can be enabled (and applied with tbuild and tup of this container) to optimise memory usage \
-    # Note that PHP's memory limit needs to be high enough.
-    #&& echo "pcov.initial.memory=1073741824" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
-    && echo "pcov.initial.files=30000" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini

--- a/php/php82-debug/Dockerfile
+++ b/php/php82-debug/Dockerfile
@@ -1,15 +1,6 @@
 FROM totara/docker-dev-php82:latest
 
 RUN pecl install -f xdebug-3.4.0beta1 && docker-php-ext-enable xdebug.so
-RUN pecl install -f pcov && docker-php-ext-enable pcov.so
 
 RUN echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.start_with_request=trigger" >> /usr/local/etc/php/conf.d/xdebug.ini
-
-# Set some sensible defaults
-RUN echo "pcov.enabled=1" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
-    && echo "pcov.exclude='~(vendor|tests|node_modules|.git|client|.scannerwork)~'" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
-    # The next line can be enabled (and applied with tbuild and tup of this container) to optimise memory usage \
-    # Note that PHP's memory limit needs to be high enough.
-    #&& echo "pcov.initial.memory=1073741824" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
-    && echo "pcov.initial.files=30000" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini

--- a/php/php83-debug/Dockerfile
+++ b/php/php83-debug/Dockerfile
@@ -1,15 +1,6 @@
 FROM totara/docker-dev-php83:latest
 
 RUN pecl install -f xdebug-3.4.0beta1 && docker-php-ext-enable xdebug.so
-RUN pecl install -f pcov && docker-php-ext-enable pcov.so
 
 RUN echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.start_with_request=trigger" >> /usr/local/etc/php/conf.d/xdebug.ini
-
-# Set some sensible defaults
-RUN echo "pcov.enabled=1" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
-    && echo "pcov.exclude='~(vendor|tests|node_modules|.git|client|.scannerwork)~'" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
-    # The next line can be enabled (and applied with tbuild and tup of this container) to optimise memory usage \
-    # Note that PHP's memory limit needs to be high enough.
-    #&& echo "pcov.initial.memory=1073741824" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
-    && echo "pcov.initial.files=30000" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini

--- a/php/php84-debug/Dockerfile
+++ b/php/php84-debug/Dockerfile
@@ -1,16 +1,6 @@
 FROM totara/docker-dev-php84:latest
 
-RUN pecl channel-update pecl.php.net && \
-    pecl install -f xdebug-3.4.0 && docker-php-ext-enable xdebug.so && \
-    pecl install -f pcov && docker-php-ext-enable pcov.so
+RUN pecl channel-update pecl.php.net && pecl install -f xdebug-3.4.0 && docker-php-ext-enable xdebug.so
 
 RUN echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.start_with_request=trigger" >> /usr/local/etc/php/conf.d/xdebug.ini
-
-# Set some sensible defaults
-RUN echo "pcov.enabled=1" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
-    && echo "pcov.exclude='~(vendor|tests|node_modules|.git|client|.scannerwork)~'" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
-    # The next line can be enabled (and applied with tbuild and tup of this container) to optimise memory usage \
-    # Note that PHP's memory limit needs to be high enough.
-    #&& echo "pcov.initial.memory=1073741824" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini \
-    && echo "pcov.initial.files=30000" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini


### PR DESCRIPTION
PHP Debug containers were failing to build due to pcov now being installed in the base container. This fixes that.