### PR TITLE
Improve Update behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,8 @@ use-mutagen
 mutagen.yml.lock
 .env
 !.gitkeep
-/tools/.update
+/tools/.*
+!/tools/.version
 
 # Ignore custom cron jobs that you create yourself
 /cron.d/*.cron

--- a/bin/tpull
+++ b/bin/tpull
@@ -3,10 +3,10 @@
 script_path="$( cd "$(dirname "$0")" ; pwd -P )"
 project_path="$( cd $script_path && cd ..; pwd -P )"
 
-if [ $# -eq 0 ] || [ $1 == 'all' ]; then
-    source "$project_path/tools/check_for_update.sh"
-    # pulling all images already present from docker hub
-    docker images --filter=reference='totara/docker-dev-*' --format "{{.Repository}}" | xargs -I % sh -c 'docker pull %'
+if [ $# -eq 0 ] || [ "$1" == 'all' ]; then
+    # Get all compose services using a totara/docker-dev image and only pull those
+    $script_path/tdocker pull \
+        $($script_path/tdocker config --format json | jq -r '.services | to_entries[] | select(.value.image? | startswith("totara/docker-dev")) | .key')
 else
     $script_path/tdocker pull "$@"
 fi

--- a/bin/tupdate
+++ b/bin/tupdate
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+script_path="$( cd "$(dirname "$0")" ; pwd -P )"
+project_path="$( cd $script_path && cd ..; pwd -P )"
+set -a; source "$project_path/.env"; set +a
+
+# Run the actual update script
+$project_path/tools/update.sh || echo -e "\n\x1B[31mThere was an error while updating docker-dev :(\x1B[0m"

--- a/tools/check_for_update.sh
+++ b/tools/check_for_update.sh
@@ -57,7 +57,9 @@ if [[ "$current_version_hash" == "$latest_version_hash" ]]; then
     return &> /dev/null || exit
 fi
 
-read -p "There is a newer version of totara-docker-dev available. Updating will stop all running containers. Would you like to update? [Y/n] " confirm
+echo "\033[1;35mThere is a newer version of totara-docker-dev available!\033[0m"
+echo "Updating will stop all running containers, pulling new container images and then restart your services."
+read -p "Would you like to update? [Y/n] " confirm
 if [[ "$confirm" == "y" || "$confirm" == "Y" ]]; then
     source "$project_path/tools/update.sh"
     # Containers have been stopped, so should quit out and not continue running whatever the command was.

--- a/tools/post_update.sh
+++ b/tools/post_update.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ -z $release_date ]]; then
-    echo "post_update.sh can't be run directly - please run update.sh instead"
+    echo "post_update.sh can't be run directly - please run tupdate instead"
     exit 1
 fi
 
@@ -13,14 +13,20 @@ if [[ "$release_date" -lt "20211112" ]]; then
     echo "" >> /dev/null
 fi
 
-if [[ ! $? -eq 0 ]]; then
-    # Something went wrong in the custom upgrade steps...
-    echo "An error occurred in the docker-dev specific upgrade steps!"
-    return &> /dev/null || exit
+echo -ne "\n\033[1;35mPulling the latest container images - this could take a few minutes...\033[0m\n\n"
+$project_path/bin/tpull
+
+if [[ -f "$project_path/tools/.stopped_services" ]]; then
+    echo -ne "\n\033[1;35mStarting your containers again...\033[0m\n"
+    xargs $project_path/bin/tup < "$project_path/tools/.stopped_services"
 fi
 
-echo -ne "\nPulling the latest container images - this could take a few minutes" && \
-$project_path/bin/tpull &> /dev/null && \
-echo -e "...done\n\n\x1B[2mSuccessfully updated to $new_tag from $old_tag\x1B[0m" && \
-echo "View the latest changes here: https://github.com/totara/totara-docker-dev/releases/latest" && \
-echo "Note: You will need to start your containers again with the tup command"
+echo -e "\n\033[1;35mSuccessfully updated to $new_tag!\x1B[0m"
+echo -e "\033[1;35mView the release notes here: https://github.com/totara/totara-docker-dev/releases\x1B[0m"
+
+if [[ -f "$project_path/tools/.stopped_services" ]]; then
+    rm -f "$project_path/tools/.stopped_services"
+else
+    echo "Note: You will need to start your containers again with the tup command"
+fi
+

--- a/tools/update.sh
+++ b/tools/update.sh
@@ -3,18 +3,23 @@
 script_path=$( cd "$(dirname "$0")" || exit; pwd -P )
 project_path=$( cd "$script_path" && cd ..; pwd -P )
 
+set -e
+
 old_tag=$(git describe --tags)
 
 export $(grep -E -v '^#' "$project_path/tools/.version" | xargs)
 
-# Big chain of commands we only want to run if the previous one was successful
-echo -ne "Stopping all running containers" && \
-    "$project_path"/bin/tdown &> /dev/null && \
-    echo -e "...done\n\nPulling the latest code" && \
-    git pull origin master --rebase && \
-    source $project_path/tools/post_update.sh && \
-    return &> /dev/null || exit
 
-# Something failed...
-echo -e "\n\x1B[31mThere was an error while updating.\x1B[0m"
-echo "The update can be attempted again by running the $script_path/$(basename $0) script."
+# Actual update steps
+echo -ne "\033[1;35mUpdating docker dev to the latest version!\033[0m\n\n"
+
+# Store the list of running services so they can be restarted later
+echo -ne "\033[1;35mStopping all running containers...\033[0m\n"
+echo "$(tdocker ps --services --status running | xargs)" > "$project_path/tools/.stopped_services"
+"$project_path"/bin/tdown
+
+# Rebase on the latest master in case there are any local commits
+echo -e "\033[1;35mPulling the latest code...\033[0m\n"
+git pull origin master --rebase
+
+source $project_path/tools/post_update.sh


### PR DESCRIPTION
This adds a `tupdate` command for updating docker-dev, and have improved the update scripts so that it takes note of the containers you currently have running, and will start them again once updating has finished.

To test this:
1. Check out this PR
1. Check out master
2. Revert back to an old release via `git reset --hard tags/v1.17.0`
3. Cherry-pick this PR's commit
4. Run `tupdate` and make sure it:
    * Stops all your running containers
    * Pulls new images
    * Starts containers again