### PR TITLE
v1.18.0 Bugfixes

### DIFF
--- a/bin/tdb
+++ b/bin/tdb
@@ -249,8 +249,9 @@ fi
 if [[ "$action" == 'list' ]]; then
     echo -e "\x1B[2mListing $db_type backups in ${backup_folder_local}\x1B[0m"
     (
-        files=( "$backup_folder_local"/*.${db_type} "$backup_folder_local"/*.dump)
-        [ -e "${files[0]}" ] || { echo "No $db_type backups found" >&2; exit 0; }
+        shopt -s nullglob
+        files=( "$backup_folder_local"/*.${db_type} "$backup_folder_local"/*.dump )
+        [ ${#files[@]} -eq 0 ] && { echo "No $db_type backups found" >&2; exit 0; }
 
         printf "Name\t\tDate\t\tSize\n"
         for f in "${files[@]}"; do

--- a/bin/tphp
+++ b/bin/tphp
@@ -18,11 +18,13 @@ if [[ "$1" == "debug" ]]; then
 fi
 
 # Replace local path with remote path in any file path arguments
-# e.g. /User/me/totara-sites/mysite/server/plugin/test.php -> /var/www/totara/src/mysite/server/plugin/test.php
+# e.g. //wsl.localhost/Ubuntu/home/me/totara-sites/mysite/server/plugin/test.php -> /var/www/totara/src/mysite/server/plugin/test.php
 args=()
 for arg in "$@"; do
-    if [[ "$arg" == "$LOCAL_SRC"* && -e "$arg" ]]; then
-        arg="$REMOTE_SRC${arg#$LOCAL_SRC}"
+    if [[ "$arg" == *"$LOCAL_SRC"* ]]; then
+        arg="$REMOTE_SRC${arg#*$LOCAL_SRC}"
+        # Strip any unescaped single quote characters
+        arg=$(echo "$arg" | sed "s/\([^']\)'\([^']\)/\1\2/g; s/^'//; s/'$//")
     fi
     args+=("$arg")
 done


### PR DESCRIPTION
This includes some small fixes to issues in the v1.18.0 release.

The issues are:
- Warnings appear in the terminal output when running `tdb list` with no backups or `.dump` totara box backups
- Errors when running PHPUnit tests in WSL via VS Code