### PR TITLE
fix: Fix errors when listing db backups when none exist

### DIFF
--- a/bin/tdb
+++ b/bin/tdb
@@ -249,8 +249,9 @@ fi
 if [[ "$action" == 'list' ]]; then
     echo -e "\x1B[2mListing $db_type backups in ${backup_folder_local}\x1B[0m"
     (
-        files=( "$backup_folder_local"/*.${db_type} "$backup_folder_local"/*.dump)
-        [ -e "${files[0]}" ] || { echo "No $db_type backups found" >&2; exit 0; }
+        shopt -s nullglob
+        files=( "$backup_folder_local"/*.${db_type} "$backup_folder_local"/*.dump )
+        [ ${#files[@]} -eq 0 ] && { echo "No $db_type backups found" >&2; exit 0; }
 
         printf "Name\t\tDate\t\tSize\n"
         for f in "${files[@]}"; do


### PR DESCRIPTION
This fixes warnings that appear in the terminal output when running `tdb list` with no backups or `.dump` totara box backups

To test this:
1. Check out this PR
2. In your `.env`, set `TDB_BACKUP_PATH` to a new empty directory (e.g. set it to `TDB_BACKUP_PATH="/Users/mark/test1"` and run `mkdir /Users/mark/test1`)
3. Run `tdb list` and make sure no errors are output and it outputs `No (db type) backups found`
