### PR TITLE
fix: Remove WSL path prefix when running tphp

### DIFF
--- a/bin/tphp
+++ b/bin/tphp
@@ -18,11 +18,13 @@ if [[ "$1" == "debug" ]]; then
 fi
 
 # Replace local path with remote path in any file path arguments
-# e.g. /User/me/totara-sites/mysite/server/plugin/test.php -> /var/www/totara/src/mysite/server/plugin/test.php
+# e.g. //wsl.localhost/Ubuntu/home/me/totara-sites/mysite/server/plugin/test.php -> /var/www/totara/src/mysite/server/plugin/test.php
 args=()
 for arg in "$@"; do
-    if [[ "$arg" == "$LOCAL_SRC"* && -e "$arg" ]]; then
-        arg="$REMOTE_SRC${arg#$LOCAL_SRC}"
+    if [[ "$arg" == *"$LOCAL_SRC"* ]]; then
+        arg="$REMOTE_SRC${arg#*$LOCAL_SRC}"
+        # Strip any unescaped single quote characters
+        arg=$(echo "$arg" | sed "s/\([^']\)'\([^']\)/\1\2/g; s/^'//; s/'$//")
     fi
     args+=("$arg")
 done


### PR DESCRIPTION
Fixes not being able to run PHPUnit tests in WSL when running them via VS Code

This is a windows specific issue, and does not affect MacOS

To test this (Windows only):
1. Check out this PR
2. [Follow the docs here](https://github.com/totara/totara-docker-dev/wiki/Visual-Studio-Code-Integration#running-phpunit-tests) to run PHPUnit within VS Code and ensure it works on Windows