### PR TITLE
ci: Use semantic release development workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,16 +20,5 @@ A clear and concise description of what you expected to happen.
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
 
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
-
-**Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
-
 **Additional context**
 Add any other context about the problem here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+### Description
+
+Describe what this pull request is about
+
+
+### Testing Instructions
+
+1. Check out this pull request
+2. _Testing instructions here_
+
+
+### Checklist
+
+- [ ] Does what the author says it will do
+- [ ] Testing instructions are provided
+- [ ] Commit messages make sense and follow the [conventional commit](https://www.conventionalcommits.org) standard
+- [ ] No identified security issues
+- [ ] No identified maintenance issues
+- [ ] Any third-party libraries/dependencies use the MIT or Apache 2.0 license
+- [ ] Changes made are backwards compatible and will not break existing setups
+- [ ] Changes to scripts in the `bin/` directory run correctly on both MacOS and WSL
+- [ ] Changes to containers can be built locally sucessfully (e.g. via `tbuild container && tup container`)
+- [ ] Containers/images are compatible with both AMD64 (Windows) and ARM64 (MacOS)
+- [ ] Changes made to `config.php` are compatible with our oldest supported Totara version, our newest Totara version, and Moodle

--- a/.github/actions/cc-checker/action.yml
+++ b/.github/actions/cc-checker/action.yml
@@ -1,0 +1,26 @@
+name: 'Check Conventional Commit In Pull Requests'
+description: 'Check that the PR title contains a valid task type and (optionally) a task number, and label the PR based on the task type'
+
+inputs:
+  commit-types:
+    description: 'An array of commit types. Example: ["feat","fix","docs","test","ci","refactor","perf","chore","revert"]'
+    required: true
+  github-token:
+    description: "GitHub token to authenticate requests"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+    - name: Run Conventional Commit Checker
+      run: |
+        export COMMIT_TYPES='${{ inputs.commit-types }}'
+        export GITHUB_TOKEN='${{ inputs.github-token }}'
+        cd .github/actions/cc-checker
+        npm install --no-save conventional-commits-parser@^3.2.4 @actions/core@^1.11.1 @actions/github@^6.0.1
+        node cc-checker.js
+      shell: bash

--- a/.github/actions/cc-checker/cc-checker.js
+++ b/.github/actions/cc-checker/cc-checker.js
@@ -1,0 +1,63 @@
+const { setFailed } = require('@actions/core');
+const github = require('@actions/github');
+const commitParser = require('conventional-commits-parser');
+
+async function run() {
+    const commitTypesEnv = process.env.COMMIT_TYPES;
+    if (!commitTypesEnv) {
+        setFailed('COMMIT_TYPES not found in environment.');
+        return;
+    }
+    let commitTypeList;
+    try {
+        commitTypeList = JSON.parse(commitTypesEnv);
+    } catch (err) {
+        setFailed('Invalid COMMIT_TYPES input. Expecting a JSON array.');
+        return;
+    }
+
+    const pr = github.context.payload.pull_request;
+    if (!pr) {
+        setFailed('No pull request found in context.');
+        return;
+    }
+
+    // Get the GitHub token from env
+    const token = process.env.GITHUB_TOKEN;
+    if (!token) {
+        setFailed('GITHUB_TOKEN not found in environment.');
+        return;
+    }
+
+    const octokit = github.getOctokit(token);
+    const { owner, repo } = github.context.repo;
+    const prNumber = pr.number;
+
+    // Fetch all commits in the PR
+    const commits = await octokit.rest.pulls.listCommits({
+        owner,
+        repo,
+        pull_number: prNumber,
+    });
+
+    let failed = false;
+    let errors = [];
+    for (const commit of commits.data) {
+        const message = commit.commit.message.split('\n')[0].trim();
+        const ast = commitParser.sync(message);
+        const type = ast.type ? ast.type : '';
+        if (!type || !commitTypeList.includes(type)) {
+            failed = true;
+            errors.push(`Commit ${commit.sha}: Invalid or missing commit type: '${type}'. Must be one of: ${commitTypeList.join(', ')}`);
+        }
+    }
+    if (failed) {
+        setFailed(errors.join('\n'));
+        return;
+    }
+    return true;
+}
+
+run().catch(err => setFailed(err.message));
+
+module.exports = { run };

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,35 @@
+name: Create Semantic Release
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install dependencies
+        run: npm install --no-save semantic-release@^24.2.9
+      - name: Release
+        env:
+          # The RELEASE_TOKEN repository secret must be a personal access token with the permissions described here:
+          # https://github.com/semantic-release/github/blob/master/README.md#github-authentication
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: npx semantic-release

--- a/.github/workflows/validate-commits.yml
+++ b/.github/workflows/validate-commits.yml
@@ -1,0 +1,22 @@
+name: Conventional Commit Validation
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  contents: read
+
+jobs:
+  validate-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Validate commits are Conventional Commits
+        uses: ./.github/actions/cc-checker
+        with:
+          commit-types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert"]'
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -1,0 +1,8 @@
+release:
+  branches:
+    - master
+
+plugins:
+  - "@semantic-release/commit-analyzer"
+  - "@semantic-release/release-notes-generator"
+  - "@semantic-release/github"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,31 +8,17 @@ We try to collect all improvements and bug reports as Issues. Also we avoid push
 
 ## Workflow
 
-We follow the [GitFlow Workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow).
-
-## Standard workflow
-
-If you want to add a new feature or fix a bug
+If you want to add a new feature or fix a bug:
 
 1. Fork the repository
-2. Check out the **develop** branch `git checkout develop` 
-3. Create a new feature or bugfix branch `git checkout -b feature-upgrade-nodejes` (prefix with **feature**- or **bugfix**- and name it with something meaningful)
-4. Create and push your commits into your own repository
-5. Create a new Pull Request for your branch pointing to **develop**. Don't point it to **master** directly.
+2. Check out the latest **master** branch - `git checkout master && git pull` 
+3. Create a new feature or bugfix branch, for example: `git checkout -b feat-add-postgres18` (prefix with **feat**- or **fix**- and name it with something meaningful)
+4. Create commits with a [conventional commit message](https://www.conventionalcommits.org), for example: "feat: Add Postgres 18 container" or "fix: Remove usage of deprecated PHP constant"
+5. Push your commits into your own repository
+6. Create a new Pull Request for your branch pointing to **master**.
 
-When enough features come together we will merge develop into master, create a new tag and publish it as a new release. With this approach the master will always contain the latest stable version.
-
-## Hotfixes
-
-If something critical needs to be fixed and released please 
-
-1. Create a hotfix branch (prefix with hotfix- and name it properly) based on the current master
-2. Fix the code
-3. Create a new Pull Request from your hotfix branch pointing it to **master**
-4. Once it got reviewed and merged we will merge master back into develop to make sure it's in sync.
-
-## Unstable releases
-
-We might release unstable versions. Those will be tagged on develop and released clearly marked as unstable releases.
+When the pull request has been approved and merged, then a release will automatically be made,
+using [semantic versioning](https://semver.org/) based upon the conventional commit messages in the merged pull request.
+This will rebuild and push new versions of the containers.
 
 If you have any questions don't hesitate to ask.


### PR DESCRIPTION
Having to manually make releases seems somewhat arbitrary given that a lot of the changes are often unrelated, and desired by different teams. Wanting to remove the amount of effort to make and release changes, and make it so it's more decentralised so individual teams can make changes without having to involve others/wait for the next manual release (of which we don't really have a schedule for)

I’m proposing that we switch from the current release model (of merging into develop, then merging into master and manually creating a release) to a model where:
1. Commits are named using the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/) (i.e. feat/fix/chore)
2. PRs require 2 approvals rather than 1 (the idea being one Mac tester and one WSL tester)
3. PRs are merged directly into master
4. Releases are made automatically once a PR is merged (using the [semantic release](https://github.com/semantic-release/semantic-release#) process)

This then creates a release that [looks like this](https://github.com/markmetcalfe/totara-docker-dev/releases/tag/v1.15.0) (in my personal fork) that uses the conventional commit message to determine whether to increment the minor or patch version, and uses it to autogenerate release notes.
