### PR TITLE
fix: Add missing mutagen sync entries for PHP 8.4

### DIFF
--- a/compose/sync.yml
+++ b/compose/sync.yml
@@ -159,7 +159,19 @@ services:
   php-8.3-debug:
     volumes:
       - totara-www-sync:${REMOTE_SRC}:nocopy
+      
+  php-8.4:
+    volumes:
+      - totara-www-sync:${REMOTE_SRC}:nocopy
 
+  php-8.4-cron:
+    volumes:
+      - totara-www-sync:${REMOTE_SRC}:nocopy
+
+  php-8.4-debug:
+    volumes:
+      - totara-www-sync:${REMOTE_SRC}:nocopy
+  
   sync:
     image: alpine:latest
     container_name: totara_sync


### PR DESCRIPTION
### Description

Mutagen entries are missing for PHP-8.4. This adds them, which significantly improves page load times for PHP-8.4 on MacOS.

### Testing Instructions

*Requires MacOS for testing*

1. Try loading pages with php-8.4 and observe slow page load times
2. Check out this pull request
3. Run `tup php-8.4 php-8.4-debug`
4. Observe page load times are faster when loading pages with php-8.4 and php-8.4-debug 


### Checklist

- [x] Does what the author says it will do
- [x] Testing instructions are provided
- [x] Commit messages make sense and follow the [conventional commit](https://www.conventionalcommits.org) standard
- [x] No identified security issues
- [x] No identified maintenance issues
- [x] Any third-party libraries/dependencies use the MIT or Apache 2.0 license
- [x] Changes made are backwards compatible and will not break existing setups
- [x] Changes to scripts in the `bin/` directory run correctly on both MacOS and WSL
- [x] Changes to containers can be built locally sucessfully (e.g. via `tbuild container && tup container`)
- [x] Containers/images are compatible with both AMD64 (Windows) and ARM64 (MacOS)
- [x] Changes made to `config.php` are compatible with our oldest supported Totara version, our newest Totara version, and Moodle
