### PR TITLE
fix: Add missing behat hostname aliases

### DIFF
--- a/compose/apache.yml
+++ b/compose/apache.yml
@@ -53,17 +53,25 @@ services:
           - totara74.behat
           - totara74.behat.totaralms.com
           - totara80
+          - totara80.debug
           - totara80.behat
           - totara80.behat.totaralms.com
           - totara81
+          - totara81.debug
           - totara81.behat
           - totara81.behat.totaralms.com
           - totara82
+          - totara82.debug
           - totara82.behat
           - totara82.behat.totaralms.com
           - totara83
+          - totara83.debug
           - totara83.behat
           - totara83.behat.totaralms.com
+          - totara84
+          - totara84.debug
+          - totara84.behat
+          - totara84.behat.totaralms.com
 
 volumes:
   totara-data:

--- a/compose/nginx.yml
+++ b/compose/nginx.yml
@@ -54,17 +54,25 @@ services:
           - totara74.behat
           - totara74.behat.totaralms.com
           - totara80
+          - totara80.debug
           - totara80.behat
           - totara80.behat.totaralms.com
           - totara81
+          - totara81.debug
           - totara81.behat
           - totara81.behat.totaralms.com
           - totara82
+          - totara82.debug
           - totara82.behat
           - totara82.behat.totaralms.com
           - totara83
+          - totara83.debug
           - totara83.behat
           - totara83.behat.totaralms.com
+          - totara84
+          - totara84.debug
+          - totara84.behat
+          - totara84.behat.totaralms.com
 
 volumes:
   totara-data:


### PR DESCRIPTION
### Description

For behat to work correctly, there must be the correct hostname alias mappings in the nginx and apache compose configs. This adds all the ones that are missing, which will make it so behat can run with PHP 8.4


### Testing Instructions

1. Check out this pull request
2. Run `tup nginx php-8.4 && tzsh php-8.4`
3. Run `installbehat && behat server/lib/tests/behat/change_password.feature` and ensure it runs fine
4. Run `tstop nginx && tup apache`
5. Run `tzsh php-8.4 && behat server/lib/tests/behat/change_password.feature` and ensure it runs fine


### Checklist

- [x] Does what the author says it will do
- [x] Testing instructions are provided
- [x] Commit messages make sense and follow the [conventional commit](https://www.conventionalcommits.org) standard
- [ ] No identified security issues
- [ ] No identified maintenance issues
- [ ] Any third-party libraries/dependencies use the MIT or Apache 2.0 license
- [ ] Changes made are backwards compatible and will not break existing setups
- [ ] Changes to scripts in the `bin/` directory run correctly on both MacOS and WSL
- [ ] Changes to containers can be built locally sucessfully (e.g. via `tbuild container && tup container`)
- [ ] Containers/images are compatible with both AMD64 (Windows) and ARM64 (MacOS)
- [ ] Changes made to `config.php` are compatible with our oldest supported Totara version, our newest Totara version, and Moodle
