### PR TITLE
feat: Define the TOTARA_COMPOSER constant with the correct path

### DIFF
--- a/php/includes/config-after.php
+++ b/php/includes/config-after.php
@@ -298,3 +298,9 @@ $CFG->pathtogs = '/usr/bin/gs';
 $CFG->pathtodu = '/usr/bin/du';
 $CFG->aspellpath = '/usr/bin/aspell';
 $CFG->pathtodot = '/usr/bin/dot';
+
+
+// Tell Totara where composer is
+if (!defined('TOTARA_COMPOSER')) {
+    define('TOTARA_COMPOSER', '/usr/bin/composer');
+}


### PR DESCRIPTION
### Description

Preparing for Totara 20 where knowing where composer is available is semi-important.

### Testing Instructions

1. Check out this pull request
2. Confirm you can load & install a Totara instance without any noticeable changes


### Checklist

- [ ] Does what the author says it will do
- [ ] Testing instructions are provided
- [ ] Commit messages make sense and follow the [conventional commit](https://www.conventionalcommits.org) standard
- [ ] No identified security issues
- [ ] No identified maintenance issues
- [ ] Any third-party libraries/dependencies use the MIT or Apache 2.0 license
- [ ] Changes made are backwards compatible and will not break existing setups
- [ ] Changes to scripts in the `bin/` directory run correctly on both MacOS and WSL
- [ ] Changes to containers can be built locally sucessfully (e.g. via `tbuild container && tup container`)
- [ ] Containers/images are compatible with both AMD64 (Windows) and ARM64 (MacOS)
- [ ] Changes made to `config.php` are compatible with our oldest supported Totara version, our newest Totara version, and Moodle
