### PR TITLE
ci: Push images to Github container registry instead of Docker Hub

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -33,17 +33,16 @@ jobs:
         if: ${{ inputs.push == true }}
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract metadata (tags, labels) for Docker
         if: ${{ inputs.push == true }}
         id: meta
         uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96 # v5.6.1
         with:
-          images: totara/docker-dev-${{ inputs.image }}
-          tags: |
-            type=raw,latest
-            type=semver,pattern={{version}}
+          images: ghcr.io/totara/docker-dev-${{ inputs.image }}
+          tags: type=raw,latest
       - name: Set up QEMU (to support building for both amd64 and arm64)
         if: ${{ inputs.multiarch == true }}
         uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0

--- a/.github/workflows/build-mssql.yml
+++ b/.github/workflows/build-mssql.yml
@@ -9,7 +9,8 @@ on:
       - master
     paths:
       - mssql/**
-      - ./.github/workflows/build-image.yml
+      - .github/workflows/build-image.yml
+      - .github/workflows/build-mssql.yml
 
 jobs:
   build-mssql-images:

--- a/.github/workflows/build-php.yml
+++ b/.github/workflows/build-php.yml
@@ -10,7 +10,8 @@ on:
     paths:
       - php/**
       - '!php/includes/**'
-      - ./.github/workflows/build-image.yml
+      - .github/workflows/build-image.yml
+      - .github/workflows/build-php.yml
 
 jobs:
   build-php-images:


### PR DESCRIPTION
### Description

This change makes it so our container images are hosted on Github rather than on docker hub.
The benefit of doing this is cost savings. Public packages on Github are entirely free, whereas for Docker hub we have to have a paid subscription for hosting images.


### Testing Instructions

Verify that the packages uploaded correctly after [this PR has been merged](https://github.com/markmetcalfe/totara-docker-dev/pull/16):
- https://github.com/markmetcalfe/totara-docker-dev/actions/runs/19484384685
- https://github.com/markmetcalfe/totara-docker-dev/actions/runs/19484384676
- https://github.com/markmetcalfe?tab=packages&repo_name=totara-docker-dev
