### PR TITLE
fix: Remove deprecated mailcatcher container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,18 +28,6 @@ services:
     networks:
       - totara
 
-  # Deprecated - use maildev instead
-  mailcatcher:
-    image: tophfr/mailcatcher
-    container_name: totara_mailcatcher
-    restart: ${RESTART_POLICY:-no}
-    ports:
-      - "8080:80"
-    environment:
-      TZ: ${TIME_ZONE}
-    networks:
-      - totara
-
   redis:
     image: redis
     restart: ${RESTART_POLICY:-no}


### PR DESCRIPTION
### Description

This removes the mailcatcher container, which had been deprecated in favour of using the maildev container for displaying emails sent by Totara.


### Testing Instructions

1. Check out this pull request
2. Check that after running `tup` your site works as normal

### Checklist

- [ ] Does what the author says it will do
- [ ] Testing instructions are provided
- [ ] Commit messages make sense and follow the [conventional commit](https://www.conventionalcommits.org) standard
- [ ] No identified security issues
- [ ] No identified maintenance issues
- [ ] Any third-party libraries/dependencies use the MIT or Apache 2.0 license
- [ ] Changes made are backwards compatible and will not break existing setups
- [ ] Changes to scripts in the `bin/` directory run correctly on both MacOS and WSL
- [ ] Changes to containers can be built locally sucessfully (e.g. via `tbuild container && tup container`)
- [ ] Containers/images are compatible with both AMD64 (Windows) and ARM64 (MacOS)
- [ ] Changes made to `config.php` are compatible with our oldest supported Totara version, our newest Totara version, and Moodle
