### PR TITLE
feat: Add PHP 8.5 support

### DIFF
--- a/.github/workflows/build-php.yml
+++ b/.github/workflows/build-php.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [73, 74, 80, 81, 82, 83, 84]
+        version: [73, 74, 80, 81, 82, 83, 84, 85]
     with:
       image: php${{ matrix.version }}
       context: ./php

--- a/.github/workflows/scan-images.yml
+++ b/.github/workflows/scan-images.yml
@@ -26,6 +26,7 @@ jobs:
           - image: php82
           - image: php83
           - image: php84
+          - image: php85
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/validate-config.yml
+++ b/.github/workflows/validate-config.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php-version: ['8.4', '5.5']
+        php-version: ['8.5', '5.5']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Although this project started as a development environment for Totara Learn it c
 ### What You Get
  * [NGINX](https://nginx.org/) as a webserver
  * [Apache](https://httpd.apache.org/) as a webserver
- * [PHP](http://php.net/) 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4 to test for different versions
+ * [PHP](http://php.net/) 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4, 8.5 to test for different versions
  * [PostgreSQL](https://www.postgresql.org/) (9.3, 9.6, 10, 11, 12, 13, 14, 15, 16, 17), 
  * [MariaDB](https://mariadb.org/) (10.2, 10.3, 10.4, 10.5, 10.6, 10.7, 10.8, 10.11, 11.4, 11.8), 
  * [MySQL](https://www.mysql.com/) (5.7, 8.0, 8.4), 

--- a/compose/apache.yml
+++ b/compose/apache.yml
@@ -86,6 +86,12 @@ services:
           - totara84.behat
           - totara84.behat.debug
           - totara84.behat.totaralms.com
+          - totara85
+          - totara85.debug
+          - totara85.behat
+          - totara85.behat.debug
+          - totara85.behat.totaralms.com
+
 
 volumes:
   totara-data:

--- a/compose/build.yml
+++ b/compose/build.yml
@@ -112,5 +112,19 @@ services:
       args:
         TIME_ZONE: ${TIME_ZONE}
 
+  php-8.5:
+    build:
+      context: ./php
+      dockerfile: php85/Dockerfile
+      args:
+        TIME_ZONE: ${TIME_ZONE}
+
+  php-8.5-debug:
+    build:
+      context: ./php
+      dockerfile: php85/Dockerfile
+      args:
+        TIME_ZONE: ${TIME_ZONE}
+
   # php-X.X: ...
   # php-X.X-debug: ...

--- a/compose/nginx.yml
+++ b/compose/nginx.yml
@@ -87,7 +87,12 @@ services:
           - totara84.behat
           - totara84.behat.debug
           - totara84.behat.totaralms.com
-
+          - totara85
+          - totara85.debug
+          - totara85.behat
+          - totara85.behat.debug
+          - totara85.behat.totaralms.com
+          
 volumes:
   totara-data:
   coverage-report:

--- a/compose/php.yml
+++ b/compose/php.yml
@@ -370,6 +370,57 @@ services:
     networks:
       - totara
 
+  php-8.5:
+    image: ghcr.io/totara/docker-dev-php85
+    container_name: totara_php85
+    working_dir: ${REMOTE_SRC}
+    environment:
+      CONTAINERNAME: php-8.5
+      CRON_CONTAINER: ${CRON_CONTAINER:-none}
+      HIST_FILE: /root/.bash_history
+      DISABLE_AUTO_UPDATE: "true" # disables oh-my-zsh update message
+      USE_ZSH_NERDFONT: ${USE_ZSH_NERDFONT:-0}
+    volumes:
+      - ${LOCAL_SRC}:${REMOTE_SRC}
+      - totara-data:${REMOTE_DATA}
+      - ./cron.d:/etc/cron.d
+      - ./php/includes:/var/www/totara/includes
+      - coverage-report:/var/www/totara/coverage-report
+      - bash-history:/root/.bash_history
+      - zsh-history:/root/.zsh_history
+      - ./shell:/root/custom_shell
+    depends_on:
+      - php-8.5-debug
+    networks:
+      - totara     
+
+  php-8.5-debug:
+    image: ghcr.io/totara/docker-dev-php85
+    container_name: totara_php85_debug
+    working_dir: ${REMOTE_SRC}
+    environment:
+      CONTAINERNAME: php-8.5-debug
+      CRON_CONTAINER: ${CRON_CONTAINER:-none}
+      TZ: ${TIME_ZONE}
+      XDEBUG_CONFIG: client_host=${HOST_IP}
+      XDEBUG_MODE: debug
+      XDEBUG_SESSION: totara85
+      PHP_IDE_CONFIG: serverName=totara85
+      HIST_FILE: /root/.bash_history
+      DISABLE_AUTO_UPDATE: "true" # disables oh-my-zsh update message
+      USE_ZSH_NERDFONT: ${USE_ZSH_NERDFONT:-0}
+    volumes:
+      - ${LOCAL_SRC}:${REMOTE_SRC}
+      - totara-data:${REMOTE_DATA}
+      - ./cron.d:/etc/cron.d
+      - ./php/includes:/var/www/totara/includes
+      - coverage-report:/var/www/totara/coverage-report
+      - bash-history:/root/.bash_history
+      - zsh-history:/root/.zsh_history
+      - ./shell:/root/custom_shell
+    networks:
+      - totara
+
   # php-X.X: ...
   # php-X.X-debug: ...
 

--- a/compose/sync.yml
+++ b/compose/sync.yml
@@ -107,6 +107,14 @@ services:
     volumes:
       - totara-www-sync:${REMOTE_SRC}:nocopy
 
+  php-8.5:
+    volumes:
+      - totara-www-sync:${REMOTE_SRC}:nocopy
+
+  php-8.5-debug:
+    volumes:
+      - totara-www-sync:${REMOTE_SRC}:nocopy
+
   # php-X.X: ...
   # php-X.X-debug: ...
 

--- a/php/entrypoint.sh
+++ b/php/entrypoint.sh
@@ -18,4 +18,13 @@ fi
 # This prevents openssl from complaining about not having enough entropy
 openssl rand -writerand /root/.rnd
 
+# Enforce minimum PHP version for 8.5 series (>= 8.5.2)
+if php -r 'exit(PHP_MAJOR_VERSION==8 && PHP_MINOR_VERSION==5 ? 0 : 2);'; then
+    if ! php -r 'exit(version_compare(PHP_VERSION, "8.5.2", ">=") ? 0 : 1);'; then
+        echo "PHP 8.5 detected, but version $(php -r 'echo PHP_VERSION;') is < 8.5.2."
+        echo "Please rebuild/update the image to use php:8.5.2-fpm-bookworm or newer."
+        exit 1
+    fi
+fi
+
 php-fpm

--- a/php/php85/Dockerfile
+++ b/php/php85/Dockerfile
@@ -1,0 +1,168 @@
+FROM php:8.5.2-fpm-bookworm
+
+ARG TIME_ZONE=Pacific/Auckland
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        apt-transport-https \
+        libfreetype6-dev \
+        libjpeg62-turbo-dev \
+        libwebp-dev \
+        libmcrypt-dev \
+        libpng-dev \
+        libxml2-dev \
+        libicu-dev \
+        libpq-dev \
+        gnupg2 \
+        cron \
+        nano \
+        vim \
+        wget \
+        openssl \
+        locales \
+        tzdata \
+        git \
+        libzip-dev \
+        libmemcached-dev \
+        zip \
+        netcat-traditional \
+        bc \
+        ghostscript \
+        graphviz \
+        aspell \
+        libldap2-dev \
+        libltdl-dev \
+        libc-client-dev \
+        libkrb5-dev \
+        libssl-dev \
+        libpspell-dev \
+        xmlstarlet \
+        libtool \
+        bison 
+
+COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
+
+RUN docker-php-ext-install -j$(nproc) \
+        zip \
+        intl \
+        soap \
+        pdo_pgsql \
+        pdo_mysql \
+        pgsql \
+        mysqli \
+        exif \
+        ldap \
+    && docker-php-ext-configure gd \
+            --with-freetype \
+            --with-jpeg \
+            --with-webp \
+    && docker-php-ext-install -j$(nproc) gd
+
+RUN git clone https://github.com/longxinH/xhprof.git ./xhprof \
+    && cd xhprof \
+    && git checkout v2.3.10 \
+    && cd extension/ \
+    && phpize \
+    && ./configure \
+    && make && make install
+
+RUN echo "extension=xhprof.so" >> /usr/local/etc/php/conf.d/xhprof.ini \
+    && echo "xhprof.output_dir = /tmp/xhprof" >> /usr/local/etc/php/conf.d/xhprof.ini
+
+RUN pecl channel-update pecl.php.net && \
+    pecl install -o -f redis \
+    &&  rm -rf /tmp/pear \
+    &&  docker-php-ext-enable redis
+
+RUN pecl channel-update pecl.php.net && \
+    pecl install -o -f igbinary \
+    &&  rm -rf /tmp/pear \
+    &&  docker-php-ext-enable igbinary
+
+RUN pecl channel-update pecl.php.net && \
+    pecl install -o -f memcached \
+    &&  rm -rf /tmp/pear \
+    &&  docker-php-ext-enable memcached
+
+RUN pecl channel-update pecl.php.net && \
+    pecl install -o -f imap \
+    &&  rm -rf /tmp/pear \
+    &&  docker-php-ext-enable imap
+
+RUN pecl channel-update pecl.php.net && \
+    pecl install -o -f excimer \
+    &&  rm -rf /tmp/pear \
+    &&  docker-php-ext-enable excimer
+
+RUN pecl channel-update pecl.php.net && \
+    pecl install -o -f pspell \
+    &&  rm -rf /tmp/pear \
+    &&  docker-php-ext-enable pspell
+
+RUN pecl channel-update pecl.php.net && \
+    pecl install -o -f xdebug-3.5.0 \
+    &&  rm -rf /tmp/pear \
+    &&  docker-php-ext-enable xdebug.so
+
+RUN pecl channel-update pecl.php.net && \
+    pecl install -o -f pcov \
+    &&  rm -rf /tmp/pear \
+    &&  docker-php-ext-enable pcov
+
+# Install composer
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+# we need en_US locales for MSSQL connection to work
+# we need en_AU locales for behat to work
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    sed -i -e 's/# en_AU.UTF-8 UTF-8/en_AU.UTF-8 UTF-8/' /etc/locale.gen && \
+    dpkg-reconfigure --frontend=noninteractive locales && \
+    update-locale LANG=en_US.UTF-8
+
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
+
+# install mssql extension
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
+    && curl https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list \
+    && apt-get update && ACCEPT_EULA=Y apt-get install -y \
+    msodbcsql18 \
+    mssql-tools18 \
+    unixodbc-dev
+
+RUN echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bash_profile \
+    && echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc
+
+# TODO: uncomment when sqlsrv supports PHP 8.5 https://github.com/microsoft/msphpsql/releases
+# Workaround applied: https://github.com/microsoft/msphpsql/issues/1438#issuecomment-1444773949
+# RUN pear config-set php_ini `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"` system \
+#     && pecl install sqlsrv-5.12.0 pdo_sqlsrv-5.12.0 || \
+#     apt-get install -y --allow-downgrades odbcinst=2.3.7 odbcinst1debian2=2.3.7 unixodbc=2.3.7 unixodbc-dev=2.3.7 && \
+#     pecl install sqlsrv-5.12.0 pdo_sqlsrv-5.12.0
+
+# RUN docker-php-ext-enable sqlsrv.so && docker-php-ext-enable pdo_sqlsrv.so
+
+RUN ln -fs /usr/share/zoneinfo/${TIME_ZONE} /etc/localtime \
+    && dpkg-reconfigure --frontend noninteractive tzdata
+
+COPY config/php.ini /usr/local/etc/php/
+COPY config/fpm.conf /usr/local/etc/php-fpm.d/zz-totara.conf
+
+# Source each .sh file found in the /shell/ folder, always source the default_aliases.sh file first
+RUN echo 'if [[ -e "/root/custom_shell/default-aliases.sh" ]]; then source "/root/custom_shell/default-aliases.sh"; fi' >> ~/.bashrc && \
+  echo 'for f in /root/custom_shell/*.sh; do [[ "$f" != "/root/custom_shell/default-aliases.sh" && -e "$f" ]] && source "$f"; done;' >> ~/.bashrc
+
+# Have the option of using the oh my zsh shell.
+RUN apt-get update && apt-get install -y zsh
+RUN sh -c "$(curl https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" --unattended
+RUN git clone https://github.com/romkatv/powerlevel10k ~/.oh-my-zsh/custom/themes/powerlevel10k
+RUN git clone https://github.com/zsh-users/zsh-autosuggestions ~/.oh-my-zsh/custom/plugins/zsh-autosuggestions
+RUN git clone https://github.com/zsh-users/zsh-completions ~/.oh-my-zsh/custom/plugins/zsh-completions
+RUN git clone https://github.com/zsh-users/zsh-syntax-highlighting ~/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting
+RUN echo 'setopt +o nomatch' > ~/.zshrc
+RUN echo 'source ~/custom_shell/.zshrc' >> ~/.zshrc
+RUN cat ~/.bashrc >> ~/.zshrc
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT [ "/entrypoint.sh" ]


### PR DESCRIPTION
### Description

Adding support for the PHP-8.5 container.

### Testing Instructions

1. Check out this pull request
2. Build the PHP-8.5 container: `tbuild PHP-8.5`
3. Up the container: `tup PHP-8.5`
4. Test that you can load a T20 site and that you get deprecation notices.
5. Add an entry for totara85 in your debug server list in PHPStorm.
6. Add a break point in `/login/index.php`
7. Check that the break point is triggered when visiting `http://integration.totara85.debug.localhost/login/index.php`


### Checklist

- [x] Does what the author says it will do
- [x] Testing instructions are provided
- [x] Commit messages make sense and follow the [conventional commit](https://www.conventionalcommits.org) standard
- [x] No identified security issues
- [x] No identified maintenance issues
- [ ] Any third-party libraries/dependencies use the MIT or Apache 2.0 license
- [ ] Changes made are backwards compatible and will not break existing setups
- [ ] Changes to scripts in the `bin/` directory run correctly on both MacOS and WSL
- [x] Changes to containers can be built locally sucessfully (e.g. via `tbuild container && tup container`)
- [x] Containers/images are compatible with both AMD64 (Windows) and ARM64 (MacOS)
- [ ] Changes made to `config.php` are compatible with our oldest supported Totara version, our newest Totara version, and Moodle
