### PR TITLE
feat: Add Pgsql 18 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Although this project started as a development environment for Totara Learn it c
  * [NGINX](https://nginx.org/) as a webserver
  * [Apache](https://httpd.apache.org/) as a webserver
  * [PHP](http://php.net/) 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4, 8.5 to test for different versions
- * [PostgreSQL](https://www.postgresql.org/) (9.3, 9.6, 10, 11, 12, 13, 14, 15, 16, 17), 
+ * [PostgreSQL](https://www.postgresql.org/) (9.3, 9.6, 10, 11, 12, 13, 14, 15, 16, 17, 18), 
  * [MariaDB](https://mariadb.org/) (10.2, 10.3, 10.4, 10.5, 10.6, 10.7, 10.8, 10.11, 11.4, 11.8), 
  * [MySQL](https://www.mysql.com/) (5.7, 8.0, 8.4), 
  * Microsoft SQL Server ([2017](https://www.microsoft.com/en-us/sql-server/sql-server-2017), [2019](https://www.microsoft.com/en-us/sql-server/sql-server-2019), [2022](https://www.microsoft.com/en-us/sql-server/sql-server-2022))

--- a/compose/pgsql.yml
+++ b/compose/pgsql.yml
@@ -199,6 +199,26 @@ services:
     networks:
       - totara
 
+  pgsql18:
+    image: postgres:18-alpine
+    container_name: totara_pgsql18
+    restart: ${RESTART_POLICY:-no}
+    ports:
+      - "5447:5432"
+    environment:
+      TZ: ${TIME_ZONE}
+      PGDATA: /var/lib/postgresql/docker/pgdata
+      POSTGRES_HOST_AUTH_METHOD: trust
+    command:
+      postgres -c 'config_file=/etc/postgresql/postgresql.conf'
+    volumes:
+      - ./pgsql/my-postgres.conf:/etc/postgresql/postgresql.conf
+      - pgsql18-data:/var/lib/postgresql/docker
+    depends_on:
+      - nginx
+    networks:
+      - totara
+
 volumes:
   pgsql93-data:
   pgsql96-data:
@@ -210,3 +230,4 @@ volumes:
   pgsql15-data:
   pgsql16-data:
   pgsql17-data:
+  pgsql18-data:


### PR DESCRIPTION
### Description

Adding the Pgsql 18 container for Totara 21 support.

### Testing Instructions

1. Check out this pull request
2. Change your config.php to the new version of Postgres.
3. Add the Database as a data source in IntelliJ/PHPStorm, ensure all schemas are selected.
4. Run tdb recreate
5.  Run tphp install
6. You should be able to view the database either in the UI or though tdb shell then SHOW TABLES;

### Checklist

- [ ] Does what the author says it will do
- [ ] Testing instructions are provided
- [ ] Commit messages make sense and follow the [conventional commit](https://www.conventionalcommits.org) standard
- [ ] No identified security issues
- [ ] No identified maintenance issues
- [ ] Any third-party libraries/dependencies use the MIT or Apache 2.0 license
- [ ] Changes made are backwards compatible and will not break existing setups
- [ ] Changes to scripts in the `bin/` directory run correctly on both MacOS and WSL
- [ ] Changes to containers can be built locally sucessfully (e.g. via `tbuild container && tup container`)
- [ ] Containers/images are compatible with both AMD64 (Windows) and ARM64 (MacOS)
- [ ] Changes made to `config.php` are compatible with our oldest supported Totara version, our newest Totara version, and Moodle
