### PR TITLE
feat: add tpurge command as a convenience alias

### DIFF
--- a/bin/tpurge
+++ b/bin/tpurge
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+script_path="$( cd "$(dirname "$0")" ; pwd -P )"
+
+# If the container isn't specified, then we just default to the default php container.
+container="$1"
+if [[ -z "$container" ]]; then
+    container="php"
+fi
+
+if [[ ! "$container" =~ "php" ]]; then
+    echo "tzsh only supports php containers"
+    exit 1
+fi
+
+$script_path/texec "$container" php server/admin/cli/purge_caches.php


### PR DESCRIPTION
### Description

Describe what this pull request is about


### Testing Instructions

1. Check out this pull request
2. run tpurge
3. this should run the purge cache command


### Checklist

- [ ] Does what the author says it will do
- [ ] Testing instructions are provided
- [ ] Commit messages make sense and follow the [conventional commit](https://www.conventionalcommits.org) standard
- [ ] No identified security issues
- [ ] No identified maintenance issues
- [ ] Any third-party libraries/dependencies use the MIT or Apache 2.0 license
- [ ] Changes made are backwards compatible and will not break existing setups
- [ ] Changes to scripts in the `bin/` directory run correctly on both MacOS and WSL
- [ ] Changes to containers can be built locally sucessfully (e.g. via `tbuild container && tup container`)
- [ ] Containers/images are compatible with both AMD64 (Windows) and ARM64 (MacOS)
- [ ] Changes made to `config.php` are compatible with our oldest supported Totara version, our newest Totara version, and Moodle
