### PR TITLE
feat: Add pcntl to PHP 8.4/8.5 containers

### DIFF
--- a/php/php84/Dockerfile
+++ b/php/php84/Dockerfile
@@ -47,6 +47,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         mysqli \
         exif \
         ldap \
+        pcntl \
     && docker-php-ext-configure gd \
             --with-freetype \
             --with-jpeg \

--- a/php/php85/Dockerfile
+++ b/php/php85/Dockerfile
@@ -51,6 +51,7 @@ RUN docker-php-ext-install -j$(nproc) \
         mysqli \
         exif \
         ldap \
+        pcntl \
     && docker-php-ext-configure gd \
             --with-freetype \
             --with-jpeg \


### PR DESCRIPTION
### Description

Add pcntl to the PHP 8.4/8.5 containers. pcntl is an extension that allows listening for signals, such as `SIGINT` sent by Ctrl-C. It is used by a dev script in Totara 21.

### Testing Instructions

1. Check out this pull request
2. Rebuild the containers (`tbuild php-8.4 && tup php-8.4`), run `php -m | grep pcntl` inside `texec php-8.4 bash`. Repeat for 8.5.

### Checklist

- [ ] Does what the author says it will do
- [ ] Testing instructions are provided
- [ ] Commit messages make sense and follow the [conventional commit](https://www.conventionalcommits.org) standard
- [ ] No identified security issues
- [ ] No identified maintenance issues
- [ ] Any third-party libraries/dependencies use the MIT or Apache 2.0 license
- [ ] Changes made are backwards compatible and will not break existing setups
- [ ] Changes to scripts in the `bin/` directory run correctly on both MacOS and WSL
- [ ] Changes to containers can be built locally sucessfully (e.g. via `tbuild container && tup container`)
- [ ] Containers/images are compatible with both AMD64 (Windows) and ARM64 (MacOS)
- [ ] Changes made to `config.php` are compatible with our oldest supported Totara version, our newest Totara version, and Moodle
