### PR TITLE
fix: Update ngrok regex to include .dev domains

### DIFF
--- a/php/includes/config-after.php
+++ b/php/includes/config-after.php
@@ -245,8 +245,8 @@ if ($DOCKER_DEV->major_version > 18) {
 
 // wwwroot setup
 
-// Matches URL with ngrok.app, ngrok-free.app or ngrok.pizza
-$ngrok_hostname_regex = '/\b(?:ngrok-free\.app|ngrok\.app|ngrok\.pizza)\b/';
+// Matches URL with ngrok.app, ngrok-free.app, ngrok.dev, ngrok-free.dev or ngrok.pizza
+$ngrok_hostname_regex = '/\b(?:ngrok-free\.app|ngrok\.app|ngrok-free\.dev|ngrok\.dev|ngrok\.pizza)\b/';
 if (!empty($_SERVER['HTTP_X_FORWARDED_HOST']) && preg_match($ngrok_hostname_regex, $_SERVER['HTTP_X_FORWARDED_HOST'])) {
     // Request came via ngrok
     $_SERVER['HTTP_HOST'] = $_SERVER['HTTP_X_FORWARDED_HOST'];


### PR DESCRIPTION
### Description

Add .dev domains to the ngrok hostname regex. The free tier uses ngrok-free.dev for automatically assigned URLs, while paid users may use ngrok.dev. Previously only .app and .pizza domains were matched, meaning free-tier ngrok tunnels would not be recognised.

### Testing Instructions

1. Check out this pull request
2. Start a ngrok free-tier tunnel which will generate a ngrok-free.dev URL
3. Verify the tunnel is recognised and behaves correctly
4. Use a paid account to repeat steps 2-3 with a ngrok.dev URL
4. Use a paid account to confirm existing ngrok.app and ngrok.pizza URLs still work as before


### Checklist

- [ ] Does what the author says it will do
- [ ] Testing instructions are provided
- [ ] Commit messages make sense and follow the [conventional commit](https://www.conventionalcommits.org) standard
- [ ] No identified security issues
- [ ] No identified maintenance issues
- [ ] Any third-party libraries/dependencies use the MIT or Apache 2.0 license
- [ ] Changes made are backwards compatible and will not break existing setups
- [ ] Changes to scripts in the `bin/` directory run correctly on both MacOS and WSL
- [ ] Changes to containers can be built locally sucessfully (e.g. via `tbuild container && tup container`)
- [ ] Containers/images are compatible with both AMD64 (Windows) and ARM64 (MacOS)
- [ ] Changes made to `config.php` are compatible with our oldest supported Totara version, our newest Totara version, and Moodle
