### PR TITLE
feat: Add healthchecks to all database type services

### DIFF
--- a/compose/mariadb.yml
+++ b/compose/mariadb.yml
@@ -1,6 +1,23 @@
+x-healthcheck-template: &mariadb-healthcheck
+  healthcheck:
+    test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+    interval: 5s
+    timeout: 5s
+    retries: 5
+    start_period: 10s
+
+x-healthcheck-template-legacy: &mariadb-healthcheck-legacy
+  healthcheck:
+    test: ["CMD-SHELL", "mysqladmin -u root -p$$MYSQL_ROOT_PASSWORD ping -h 127.0.0.1 2>/dev/null"]
+    interval: 5s
+    timeout: 5s
+    retries: 5
+    start_period: 10s
+
 services:
 
   mariadb1108:
+    <<: *mariadb-healthcheck
     image: mariadb:11.8
     container_name: totara_mariadb1108
     restart: ${RESTART_POLICY:-no}
@@ -18,6 +35,7 @@ services:
       - totara
 
   mariadb1104:
+    <<: *mariadb-healthcheck
     image: mariadb:11.4
     container_name: totara_mariadb1104
     restart: ${RESTART_POLICY:-no}
@@ -35,6 +53,7 @@ services:
       - totara
 
   mariadb1011:
+    <<: *mariadb-healthcheck
     image: mariadb:10.11
     container_name: totara_mariadb1011
     restart: ${RESTART_POLICY:-no}
@@ -52,6 +71,7 @@ services:
       - totara
 
   mariadb108:
+    <<: *mariadb-healthcheck
     image: mariadb:10.8
     container_name: totara_mariadb108
     restart: ${RESTART_POLICY:-no}
@@ -69,6 +89,7 @@ services:
       - totara
 
   mariadb107:
+    <<: *mariadb-healthcheck
     image: mariadb:10.7
     container_name: totara_mariadb107
     restart: ${RESTART_POLICY:-no}
@@ -86,6 +107,7 @@ services:
       - totara
 
   mariadb106:
+    <<: *mariadb-healthcheck
     image: mariadb:10.6
     container_name: totara_mariadb106
     restart: ${RESTART_POLICY:-no}
@@ -103,6 +125,7 @@ services:
       - totara
 
   mariadb105:
+    <<: *mariadb-healthcheck
     image: mariadb:10.5
     container_name: totara_mariadb105
     restart: ${RESTART_POLICY:-no}
@@ -120,6 +143,7 @@ services:
       - totara
 
   mariadb104:
+    <<: *mariadb-healthcheck
     image: mariadb:10.4
     container_name: totara_mariadb104
     restart: ${RESTART_POLICY:-no}
@@ -137,6 +161,7 @@ services:
       - totara
 
   mariadb103:
+    <<: *mariadb-healthcheck-legacy
     image: mariadb:10.3
     container_name: totara_mariadb103
     restart: ${RESTART_POLICY:-no}
@@ -154,6 +179,7 @@ services:
       - totara
 
   mariadb102:
+    <<: *mariadb-healthcheck-legacy
     image: mariadb:10.2
     container_name: totara_mariadb102
     restart: ${RESTART_POLICY:-no}

--- a/compose/mssql.yml
+++ b/compose/mssql.yml
@@ -1,6 +1,23 @@
+x-healthcheck-template: &mssql-healthcheck
+  healthcheck:
+    test: ["CMD-SHELL", "/opt/mssql-tools18/bin/sqlcmd -S 127.0.0.1 -U sa -P $$MSSQL_SA_PASSWORD -Q 'SELECT 1' -C 2>/dev/null"]
+    interval: 5s
+    timeout: 5s
+    retries: 5
+    start_period: 30s
+
+x-healthcheck-template-legacy: &mssql-healthcheck-legacy
+  healthcheck:
+    test: ["CMD-SHELL", "/opt/mssql-tools/bin/sqlcmd -S 127.0.0.1 -U sa -P $$SA_PASSWORD -Q 'SELECT 1' 2>/dev/null"]
+    interval: 5s
+    timeout: 5s
+    retries: 5
+    start_period: 30s
+
 services:
 
   mssql2017:
+    <<: *mssql-healthcheck-legacy
     image: ghcr.io/totara/docker-dev-mssql2017
     # Mssql does not support multiple architectures
     platform: linux/amd64
@@ -21,6 +38,7 @@ services:
       - totara
 
   mssql2019:
+    <<: *mssql-healthcheck-legacy
     image: ghcr.io/totara/docker-dev-mssql2019
     # Mssql does not support multiple architectures
     platform: linux/amd64
@@ -41,6 +59,7 @@ services:
       - totara
 
   mssql2022:
+    <<: *mssql-healthcheck
     image: ghcr.io/totara/docker-dev-mssql2022
     # Mssql does not support multiple architectures
     platform: linux/amd64

--- a/compose/mysql.yml
+++ b/compose/mysql.yml
@@ -1,6 +1,15 @@
+x-healthcheck-template: &mysql-healthcheck
+  healthcheck:
+    test: ["CMD-SHELL", "mysqladmin -u root -p$$MYSQL_ROOT_PASSWORD ping -h 127.0.0.1 2>/dev/null"]
+    interval: 5s
+    timeout: 5s
+    retries: 5
+    start_period: 10s
+
 services:
 
   mysql8:
+    <<: *mysql-healthcheck
     image: mysql:8.0
     container_name: totara_mysql8
     restart: ${RESTART_POLICY:-no}
@@ -18,6 +27,7 @@ services:
       - totara
 
   mysql84:
+    <<: *mysql-healthcheck
     image: mysql:8.4
     container_name: totara_mysql84
     restart: ${RESTART_POLICY:-no}
@@ -37,6 +47,7 @@ services:
   mysql57:
     # MySQL 5.7 does not support multiple architectures. (MySQL 8.0 works fine)
     platform: linux/amd64
+    <<: *mysql-healthcheck
     image: mysql:5.7
     container_name: totara_mysql57
     restart: ${RESTART_POLICY:-no}

--- a/compose/pgsql.yml
+++ b/compose/pgsql.yml
@@ -1,6 +1,15 @@
+x-healthcheck-template: &postgres-healthcheck
+  healthcheck:
+    test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER:-postgres}"]
+    interval: 5s
+    timeout: 5s
+    retries: 5
+    start_period: 10s
+
 services:
 
   pgsql93:
+    <<: *postgres-healthcheck
     image: postgres:9.3-alpine
     container_name: totara_pgsql93
     restart: ${RESTART_POLICY:-no}
@@ -20,6 +29,7 @@ services:
       - totara
 
   pgsql96:
+    <<: *postgres-healthcheck
     image: postgres:9.6-alpine
     container_name: totara_pgsql96
     restart: ${RESTART_POLICY:-no}
@@ -40,6 +50,7 @@ services:
       - totara
 
   pgsql10:
+    <<: *postgres-healthcheck
     image: postgres:10-alpine
     container_name: totara_pgsql10
     restart: ${RESTART_POLICY:-no}
@@ -60,6 +71,7 @@ services:
       - totara
 
   pgsql11:
+    <<: *postgres-healthcheck
     image: postgres:11-alpine
     container_name: totara_pgsql11
     restart: ${RESTART_POLICY:-no}
@@ -80,6 +92,7 @@ services:
       - totara
 
   pgsql12:
+    <<: *postgres-healthcheck
     image: postgres:12-alpine
     container_name: totara_pgsql12
     restart: ${RESTART_POLICY:-no}
@@ -100,6 +113,7 @@ services:
       - totara
 
   pgsql13:
+    <<: *postgres-healthcheck
     image: postgres:13-alpine
     container_name: totara_pgsql13
     restart: ${RESTART_POLICY:-no}
@@ -120,6 +134,7 @@ services:
       - totara
 
   pgsql14:
+    <<: *postgres-healthcheck
     image: postgres:14-alpine
     container_name: totara_pgsql14
     restart: ${RESTART_POLICY:-no}
@@ -140,6 +155,7 @@ services:
       - totara
 
   pgsql15:
+    <<: *postgres-healthcheck
     image: postgres:15-alpine
     container_name: totara_pgsql15
     restart: ${RESTART_POLICY:-no}
@@ -160,6 +176,7 @@ services:
       - totara
 
   pgsql16:
+    <<: *postgres-healthcheck
     image: postgres:16-alpine
     container_name: totara_pgsql16
     restart: ${RESTART_POLICY:-no}
@@ -180,6 +197,7 @@ services:
       - totara
     
   pgsql17:
+    <<: *postgres-healthcheck
     image: postgres:17-alpine
     container_name: totara_pgsql17
     restart: ${RESTART_POLICY:-no}
@@ -200,6 +218,7 @@ services:
       - totara
 
   pgsql18:
+    <<: *postgres-healthcheck
     image: postgres:18-alpine
     container_name: totara_pgsql18
     restart: ${RESTART_POLICY:-no}


### PR DESCRIPTION
### Description

Introduces healthchecks for all database type services (postgres, mariadb, mssql and mysql).

### Testing Instructions

1. Check out this pull request
2. For each database type, verify healthcheck block is present in the service definition:
```
./bin/tdocker config pgsql16
./bin/tdocker config mariadb1104
./bin/tdocker config mysql84
./bin/tdocker config mssql2022
```
3. Start each service with `--wait` and verify the command blocks until the container reaches `(healthy)`:
```
./bin/tdocker up --wait pgsql16
./bin/tdocker up --wait mariadb1104
./bin/tdocker up --wait mysql84
./bin/tdocker up --wait mssql2022
```
4. Run `docker ps` and confirm `(healthy)` appears in the status column for each started container.
5. Optionally test legacy versions to verify the correct healthcheck variant is applied:
```
./bin/tdocker up --wait mariadb102
./bin/tdocker up --wait mariadb103
./bin/tdocker up --wait mssql2017
```

### Checklist

- [x] Does what the author says it will do
- [x] Testing instructions are provided
- [x] Commit messages make sense and follow the [conventional commit](https://www.conventionalcommits.org) standard
- [x] No identified security issues
- [x] No identified maintenance issues
- [x] Any third-party libraries/dependencies use the MIT or Apache 2.0 license
- [x] Changes made are backwards compatible and will not break existing setups
- [x] Changes to scripts in the `bin/` directory run correctly on both MacOS and WSL
- [x] Changes to containers can be built locally sucessfully (e.g. via `tbuild container && tup container`)
- [x] Containers/images are compatible with both AMD64 (Windows) and ARM64 (MacOS)
- [x] Changes made to `config.php` are compatible with our oldest supported Totara version, our newest Totara version, and Moodle
