### PR TITLE
fix: Set mssql database in single user mode before droping or restori…

### DIFF
--- a/bin/tdb
+++ b/bin/tdb
@@ -475,11 +475,13 @@ elif [ "$db_type" == 'mssql' ]; then
 
     # Drop and create mssql database
     elif [ "$action" == 'recreate' ]; then
+        db_sql_cmd "ALTER DATABASE $db_name SET SINGLE_USER WITH ROLLBACK IMMEDIATE;"
         db_sql_cmd "DROP DATABASE IF EXISTS $db_name"
         db_sql_cmd "CREATE DATABASE $db_name COLLATE Latin1_General_CS_AS ALTER DATABASE $db_name SET ANSI_NULLS ON ALTER DATABASE $db_name SET QUOTED_IDENTIFIER ON ALTER DATABASE $db_name SET READ_COMMITTED_SNAPSHOT ON" || exit
 
     # Drop mssql database
     elif [ "$action" == 'drop' ]; then
+        db_sql_cmd "ALTER DATABASE $db_name SET SINGLE_USER WITH ROLLBACK IMMEDIATE;"
         db_sql_cmd "DROP DATABASE $db_name" || exit
 
     # Backup mssql database
@@ -491,7 +493,9 @@ elif [ "$db_type" == 'mssql' ]; then
     # Restore mssql database
     elif [ "$action" == 'restore' ]; then
         docker cp --quiet "$backup_file_local" "$db_container":"$backup_file_remote"
+        db_sql_cmd "ALTER DATABASE $db_name SET SINGLE_USER WITH ROLLBACK IMMEDIATE;"
         db_sql_cmd "RESTORE DATABASE $db_name FROM DISK='$backup_file_remote' WITH REPLACE" "$db_command sh -c \"rm $backup_file_remote\"" || exit
+        db_sql_cmd "ALTER DATABASE $db_name SET MULTI_USER WITH ROLLBACK IMMEDIATE;"
 
     # Start mssql shell
     elif [ "$action" == 'shell' ]; then


### PR DESCRIPTION
…ng to kill existing connections

### Description

If there are existing connections into the SQL Server database, running `tdb restore`, `tdb recreate` or` tdb drop` will fail. A common scenario is when SQL Server Management studio or PHP Storm is used to query the database. Instead of having to manually kill the sessions, TDB will set the database in single user mode and, because of that query, claim the single user spot. This disconnects all other clients and rolls back open transactions.
At the end of the restore, the database is set back to multiuser mode.


### Testing Instructions

1. Check out this pull request
2. Create a new mssql2022 database 
3. Open a shell into the server: (e.g. on the php-8.4 container, run `/opt/mssql-tools18/bin/sqlcmd -S mssql2022 -U SA -P "Totara.Mssql1" -C`)
4. Switch the context to the database `use integration;` and then `go`
5. On a separate shell, try to recreate the database (`tdb recreate`)
6. The database is recreated and the shell remains open

Without this patch, the recreate will fail with the message:
```
Msg 3101, Level 16, State 1, Server 4beb7a4e6f97, Line 1
Exclusive access could not be obtained because the database is in use.
Msg 3013, Level 16, State 1, Server 4beb7a4e6f97, Line 1
RESTORE DATABASE is terminating abnormally.
```

