### PR TITLE
feat: Add tcomposer command

### DIFF
--- a/bin/tcomposer
+++ b/bin/tcomposer
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+script_path="$( cd "$(dirname "$0")" ; pwd -P )"
+
+if [[ "$1" == "debug" ]]; then
+    shift
+    $script_path/tphp debug composer "$@"
+else
+    $script_path/tphp composer "$@"
+fi


### PR DESCRIPTION
### Description

Adds a `tcomposer` helper command as a shorthand for running Composer through the PHP container.

The command delegates to `tphp composer ...`, with `tcomposer debug ...` delegating to `tphp debug composer ...` for the debug PHP container.

Fixes #375.

### Testing Instructions

1. Check out this pull request.
2. Run `tcomposer install` and verify it runs Composer in the default PHP container.
3. Run `tcomposer debug install` and verify it runs Composer in the debug PHP container.

### Checklist

- [x] Does what the author says it will do
- [x] Testing instructions are provided
- [x] Commit messages make sense and follow the [conventional commit](https://www.conventionalcommits.org) standard
- [x] No identified security issues
- [x] No identified maintenance issues
- [x] Any third-party libraries/dependencies use the MIT or Apache 2.0 license
- [x] Changes made are backwards compatible and will not break existing setups
- [ ] Changes to scripts in the `bin/` directory run correctly on both MacOS and WSL
- [ ] Changes to containers can be built locally sucessfully (e.g. via `tbuild container && tup container`)
- [x] Containers/images are compatible with both AMD64 (Windows) and ARM64 (MacOS)
- [x] Changes made to `config.php` are compatible with our oldest supported Totara version, our newest Totara version, and Moodle

Local verification:

- `git diff --check`
- `bash -n bin/tcomposer`