### PR TITLE
feat: Add additional PHP locales

### DIFF
--- a/php/php73/Dockerfile
+++ b/php/php73/Dockerfile
@@ -88,8 +88,18 @@ COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
 # we need en_US locales for MSSQL connection to work
 # we need en_AU locales for behat to work
-RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
-    sed -i -e 's/# en_AU.UTF-8 UTF-8/en_AU.UTF-8 UTF-8/' /etc/locale.gen && \
+# Extra locales allow testing non-English and RTL formatting
+RUN for locale in \
+        en_US.UTF-8 \
+        en_AU.UTF-8 \
+        de_DE.UTF-8 \
+        fr_FR.UTF-8 \
+        es_ES.UTF-8 \
+        ar_AE.UTF-8 \
+        he_IL.UTF-8; \
+    do \
+        sed -i -e "s/# ${locale} UTF-8/${locale} UTF-8/" /etc/locale.gen; \
+    done && \
     dpkg-reconfigure --frontend=noninteractive locales && \
     update-locale LANG=en_US.UTF-8
 

--- a/php/php74/Dockerfile
+++ b/php/php74/Dockerfile
@@ -83,8 +83,18 @@ COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
 # we need en_US locales for MSSQL connection to work
 # we need en_AU locales for behat to work
-RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
-    sed -i -e 's/# en_AU.UTF-8 UTF-8/en_AU.UTF-8 UTF-8/' /etc/locale.gen && \
+# Extra locales allow testing non-English and RTL formatting
+RUN for locale in \
+        en_US.UTF-8 \
+        en_AU.UTF-8 \
+        de_DE.UTF-8 \
+        fr_FR.UTF-8 \
+        es_ES.UTF-8 \
+        ar_AE.UTF-8 \
+        he_IL.UTF-8; \
+    do \
+        sed -i -e "s/# ${locale} UTF-8/${locale} UTF-8/" /etc/locale.gen; \
+    done && \
     dpkg-reconfigure --frontend=noninteractive locales && \
     update-locale LANG=en_US.UTF-8
 

--- a/php/php80/Dockerfile
+++ b/php/php80/Dockerfile
@@ -83,8 +83,18 @@ COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
 # we need en_US locales for MSSQL connection to work
 # we need en_AU locales for behat to work
-RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
-    sed -i -e 's/# en_AU.UTF-8 UTF-8/en_AU.UTF-8 UTF-8/' /etc/locale.gen && \
+# Extra locales allow testing non-English and RTL formatting
+RUN for locale in \
+        en_US.UTF-8 \
+        en_AU.UTF-8 \
+        de_DE.UTF-8 \
+        fr_FR.UTF-8 \
+        es_ES.UTF-8 \
+        ar_AE.UTF-8 \
+        he_IL.UTF-8; \
+    do \
+        sed -i -e "s/# ${locale} UTF-8/${locale} UTF-8/" /etc/locale.gen; \
+    done && \
     dpkg-reconfigure --frontend=noninteractive locales && \
     update-locale LANG=en_US.UTF-8
 

--- a/php/php81/Dockerfile
+++ b/php/php81/Dockerfile
@@ -89,8 +89,18 @@ COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
 # we need en_US locales for MSSQL connection to work
 # we need en_AU locales for behat to work
-RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
-    sed -i -e 's/# en_AU.UTF-8 UTF-8/en_AU.UTF-8 UTF-8/' /etc/locale.gen && \
+# Extra locales allow testing non-English and RTL formatting
+RUN for locale in \
+        en_US.UTF-8 \
+        en_AU.UTF-8 \
+        de_DE.UTF-8 \
+        fr_FR.UTF-8 \
+        es_ES.UTF-8 \
+        ar_AE.UTF-8 \
+        he_IL.UTF-8; \
+    do \
+        sed -i -e "s/# ${locale} UTF-8/${locale} UTF-8/" /etc/locale.gen; \
+    done && \
     dpkg-reconfigure --frontend=noninteractive locales && \
     update-locale LANG=en_US.UTF-8
 

--- a/php/php82/Dockerfile
+++ b/php/php82/Dockerfile
@@ -89,8 +89,18 @@ COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
 # we need en_US locales for MSSQL connection to work
 # we need en_AU locales for behat to work
-RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
-    sed -i -e 's/# en_AU.UTF-8 UTF-8/en_AU.UTF-8 UTF-8/' /etc/locale.gen && \
+# Extra locales allow testing non-English and RTL formatting
+RUN for locale in \
+        en_US.UTF-8 \
+        en_AU.UTF-8 \
+        de_DE.UTF-8 \
+        fr_FR.UTF-8 \
+        es_ES.UTF-8 \
+        ar_AE.UTF-8 \
+        he_IL.UTF-8; \
+    do \
+        sed -i -e "s/# ${locale} UTF-8/${locale} UTF-8/" /etc/locale.gen; \
+    done && \
     dpkg-reconfigure --frontend=noninteractive locales && \
     update-locale LANG=en_US.UTF-8
 

--- a/php/php83/Dockerfile
+++ b/php/php83/Dockerfile
@@ -89,8 +89,18 @@ COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
 # we need en_US locales for MSSQL connection to work
 # we need en_AU locales for behat to work
-RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
-    sed -i -e 's/# en_AU.UTF-8 UTF-8/en_AU.UTF-8 UTF-8/' /etc/locale.gen && \
+# Extra locales allow testing non-English and RTL formatting
+RUN for locale in \
+        en_US.UTF-8 \
+        en_AU.UTF-8 \
+        de_DE.UTF-8 \
+        fr_FR.UTF-8 \
+        es_ES.UTF-8 \
+        ar_AE.UTF-8 \
+        he_IL.UTF-8; \
+    do \
+        sed -i -e "s/# ${locale} UTF-8/${locale} UTF-8/" /etc/locale.gen; \
+    done && \
     dpkg-reconfigure --frontend=noninteractive locales && \
     update-locale LANG=en_US.UTF-8
 

--- a/php/php84/Dockerfile
+++ b/php/php84/Dockerfile
@@ -110,8 +110,18 @@ COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
 # we need en_US locales for MSSQL connection to work
 # we need en_AU locales for behat to work
-RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
-    sed -i -e 's/# en_AU.UTF-8 UTF-8/en_AU.UTF-8 UTF-8/' /etc/locale.gen && \
+# Extra locales allow testing non-English and RTL formatting
+RUN for locale in \
+        en_US.UTF-8 \
+        en_AU.UTF-8 \
+        de_DE.UTF-8 \
+        fr_FR.UTF-8 \
+        es_ES.UTF-8 \
+        ar_AE.UTF-8 \
+        he_IL.UTF-8; \
+    do \
+        sed -i -e "s/# ${locale} UTF-8/${locale} UTF-8/" /etc/locale.gen; \
+    done && \
     dpkg-reconfigure --frontend=noninteractive locales && \
     update-locale LANG=en_US.UTF-8
 

--- a/php/php85/Dockerfile
+++ b/php/php85/Dockerfile
@@ -114,8 +114,18 @@ COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
 # we need en_US locales for MSSQL connection to work
 # we need en_AU locales for behat to work
-RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
-    sed -i -e 's/# en_AU.UTF-8 UTF-8/en_AU.UTF-8 UTF-8/' /etc/locale.gen && \
+# Extra locales allow testing non-English and RTL formatting
+RUN for locale in \
+        en_US.UTF-8 \
+        en_AU.UTF-8 \
+        de_DE.UTF-8 \
+        fr_FR.UTF-8 \
+        es_ES.UTF-8 \
+        ar_AE.UTF-8 \
+        he_IL.UTF-8; \
+    do \
+        sed -i -e "s/# ${locale} UTF-8/${locale} UTF-8/" /etc/locale.gen; \
+    done && \
     dpkg-reconfigure --frontend=noninteractive locales && \
     update-locale LANG=en_US.UTF-8
 


### PR DESCRIPTION
### Description

Adds additional UTF-8 locales to the PHP containers so developers can test non-English and RTL locale formatting without patching Dockerfiles locally.

This keeps `en_US.UTF-8` as the default environment locale and adds generated support for:

- `de_DE.UTF-8`
- `fr_FR.UTF-8`
- `es_ES.UTF-8`
- `ar_AE.UTF-8`
- `he_IL.UTF-8`

Fixes #219.

### Testing Instructions

1. Check out this pull request.
2. Build a PHP container, for example `tbuild php-8.4`.
3. Start or shell into the container.
4. Run `locale -a` and verify the added locales are available.
5. Repeat with another PHP version if needed.

### Checklist

- [x] Does what the author says it will do
- [x] Testing instructions are provided
- [x] Commit messages make sense and follow the [conventional commit](https://www.conventionalcommits.org) standard
- [x] No identified security issues
- [x] No identified maintenance issues
- [x] Any third-party libraries/dependencies use the MIT or Apache 2.0 license
- [x] Changes made are backwards compatible and will not break existing setups
- [x] Changes to scripts in the `bin/` directory run correctly on both MacOS and WSL
- [ ] Changes to containers can be built locally sucessfully (e.g. via `tbuild container && tup container`)
- [ ] Containers/images are compatible with both AMD64 (Windows) and ARM64 (MacOS)
- [x] Changes made to `config.php` are compatible with our oldest supported Totara version, our newest Totara version, and Moodle

Local verification:

- `git diff --check`
- Confirmed all PHP Dockerfiles include the added locale entries.

Container builds were not run locally because Docker is not available in this environment.