### PR TITLE
test: Add PHP image smoke checks

### DIFF
--- a/php/php73/Dockerfile
+++ b/php/php73/Dockerfile
@@ -144,6 +144,10 @@ RUN echo 'setopt +o nomatch' > ~/.zshrc
 RUN echo 'source ~/custom_shell/.zshrc' >> ~/.zshrc
 RUN cat ~/.bashrc >> ~/.zshrc
 
+COPY smoke-test.sh /usr/local/bin/totara-php-smoke-test
+RUN chmod +x /usr/local/bin/totara-php-smoke-test \
+    && /usr/local/bin/totara-php-smoke-test
+
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/php/php74/Dockerfile
+++ b/php/php74/Dockerfile
@@ -139,6 +139,10 @@ RUN echo 'setopt +o nomatch' > ~/.zshrc
 RUN echo 'source ~/custom_shell/.zshrc' >> ~/.zshrc
 RUN cat ~/.bashrc >> ~/.zshrc
 
+COPY smoke-test.sh /usr/local/bin/totara-php-smoke-test
+RUN chmod +x /usr/local/bin/totara-php-smoke-test \
+    && /usr/local/bin/totara-php-smoke-test
+
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/php/php80/Dockerfile
+++ b/php/php80/Dockerfile
@@ -139,6 +139,10 @@ RUN echo 'setopt +o nomatch' > ~/.zshrc
 RUN echo 'source ~/custom_shell/.zshrc' >> ~/.zshrc
 RUN cat ~/.bashrc >> ~/.zshrc
 
+COPY smoke-test.sh /usr/local/bin/totara-php-smoke-test
+RUN chmod +x /usr/local/bin/totara-php-smoke-test \
+    && /usr/local/bin/totara-php-smoke-test
+
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/php/php81/Dockerfile
+++ b/php/php81/Dockerfile
@@ -145,6 +145,10 @@ RUN echo 'setopt +o nomatch' > ~/.zshrc
 RUN echo 'source ~/custom_shell/.zshrc' >> ~/.zshrc
 RUN cat ~/.bashrc >> ~/.zshrc
 
+COPY smoke-test.sh /usr/local/bin/totara-php-smoke-test
+RUN chmod +x /usr/local/bin/totara-php-smoke-test \
+    && /usr/local/bin/totara-php-smoke-test
+
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/php/php82/Dockerfile
+++ b/php/php82/Dockerfile
@@ -138,6 +138,10 @@ RUN echo 'setopt +o nomatch' > ~/.zshrc
 RUN echo 'source ~/custom_shell/.zshrc' >> ~/.zshrc
 RUN cat ~/.bashrc >> ~/.zshrc
 
+COPY smoke-test.sh /usr/local/bin/totara-php-smoke-test
+RUN chmod +x /usr/local/bin/totara-php-smoke-test \
+    && /usr/local/bin/totara-php-smoke-test
+
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/php/php83/Dockerfile
+++ b/php/php83/Dockerfile
@@ -138,6 +138,10 @@ RUN echo 'setopt +o nomatch' > ~/.zshrc
 RUN echo 'source ~/custom_shell/.zshrc' >> ~/.zshrc
 RUN cat ~/.bashrc >> ~/.zshrc
 
+COPY smoke-test.sh /usr/local/bin/totara-php-smoke-test
+RUN chmod +x /usr/local/bin/totara-php-smoke-test \
+    && /usr/local/bin/totara-php-smoke-test
+
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/php/php84/Dockerfile
+++ b/php/php84/Dockerfile
@@ -159,6 +159,10 @@ RUN echo 'setopt +o nomatch' > ~/.zshrc
 RUN echo 'source ~/custom_shell/.zshrc' >> ~/.zshrc
 RUN cat ~/.bashrc >> ~/.zshrc
 
+COPY smoke-test.sh /usr/local/bin/totara-php-smoke-test
+RUN chmod +x /usr/local/bin/totara-php-smoke-test \
+    && /usr/local/bin/totara-php-smoke-test
+
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/php/php85/Dockerfile
+++ b/php/php85/Dockerfile
@@ -164,6 +164,10 @@ RUN echo 'setopt +o nomatch' > ~/.zshrc
 RUN echo 'source ~/custom_shell/.zshrc' >> ~/.zshrc
 RUN cat ~/.bashrc >> ~/.zshrc
 
+COPY smoke-test.sh /usr/local/bin/totara-php-smoke-test
+RUN chmod +x /usr/local/bin/totara-php-smoke-test \
+    && /usr/local/bin/totara-php-smoke-test
+
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/php/smoke-test.sh
+++ b/php/smoke-test.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+set -eu
+
+check_php_extension() {
+    extension="$1"
+    if ! php -r "exit(extension_loaded('$extension') ? 0 : 1);"; then
+        echo "Missing PHP extension: ${extension}" >&2
+        exit 1
+    fi
+}
+
+check_locale() {
+    locale_name="$1"
+    if ! locale -a | grep -qi "^${locale_name}[.].*utf"; then
+        echo "Missing locale: ${locale_name}.UTF-8" >&2
+        exit 1
+    fi
+}
+
+php -v >/dev/null
+composer --version >/dev/null
+php-fpm -t
+
+for extension in \
+    gd \
+    igbinary \
+    intl \
+    ldap \
+    memcached \
+    mysqli \
+    pcov \
+    pdo_mysql \
+    pdo_pgsql \
+    pgsql \
+    redis \
+    soap \
+    xdebug \
+    xhprof \
+    zip
+do
+    check_php_extension "$extension"
+done
+
+if ! php -r 'exit(PHP_MAJOR_VERSION === 8 && PHP_MINOR_VERSION === 5 ? 0 : 1);'; then
+    check_php_extension sqlsrv
+    check_php_extension pdo_sqlsrv
+fi
+
+check_locale en_US
+check_locale en_AU


### PR DESCRIPTION
### Description

Adds a common PHP image smoke-test script and runs it during each PHP Dockerfile build. The check validates core runtime expectations that the Totara dev images rely on:

- required PHP extensions are loaded
- SQL Server extensions are present on supported PHP versions
- Composer is executable
- php-fpm configuration parses successfully
- required locales are generated

Refs #38

### Testing Instructions

1. Check out this pull request
2. Build a PHP image, e.g. `docker build -f php/php83/Dockerfile php`
3. Confirm the build runs `/usr/local/bin/totara-php-smoke-test` successfully
4. Remove or disable one checked extension or locale and confirm the build fails during the smoke-test step

Local validation performed:

- `bash -n php/smoke-test.sh`
- `git diff --check`

Docker builds were not run locally because Docker is not installed on this workstation.

### Checklist

- [x] Does what the author says it will do
- [x] Testing instructions are provided
- [x] Commit messages make sense and follow the [conventional commit](https://www.conventionalcommits.org) standard
- [x] No identified security issues
- [x] No identified maintenance issues
- [x] Any third-party libraries/dependencies use the MIT or Apache 2.0 license
- [x] Changes made are backwards compatible and will not break existing setups
- [x] Changes to scripts in the `bin/` directory run correctly on both MacOS and WSL
- [ ] Changes to containers can be built locally sucessfully (e.g. via `tbuild container && tup container`)
- [ ] Containers/images are compatible with both AMD64 (Windows) and ARM64 (MacOS)
- [x] Changes made to `config.php` are compatible with our oldest supported Totara version, our newest Totara version, and Moodle