### PR TITLE
feat: Removed xdebug from normal PHP 8.4 and 8.5 containers, bumped xebug versions to latest patch release

### DIFF
--- a/compose/build.yml
+++ b/compose/build.yml
@@ -108,7 +108,7 @@ services:
   php-8.4-debug:
     build:
       context: ./php
-      dockerfile: php84/Dockerfile
+      dockerfile: php84/Dockerfile-debug
       args:
         TIME_ZONE: ${TIME_ZONE}
 
@@ -122,7 +122,7 @@ services:
   php-8.5-debug:
     build:
       context: ./php
-      dockerfile: php85/Dockerfile
+      dockerfile: php85/Dockerfile-debug
       args:
         TIME_ZONE: ${TIME_ZONE}
 

--- a/compose/php.yml
+++ b/compose/php.yml
@@ -338,13 +338,11 @@ services:
       - bash-history:/root/.bash_history
       - zsh-history:/root/.zsh_history
       - ./shell:/root/custom_shell
-    depends_on:
-      - php-8.4-debug
     networks:
       - totara
 
   php-8.4-debug:
-    image: ghcr.io/totara/docker-dev-php84
+    image: ghcr.io/totara/docker-dev-php84-debug
     container_name: totara_php84_debug
     working_dir: ${REMOTE_SRC}
     environment:
@@ -369,6 +367,8 @@ services:
       - ./shell:/root/custom_shell
     networks:
       - totara
+    depends_on:
+      - php-8.4
 
   php-8.5:
     image: ghcr.io/totara/docker-dev-php85
@@ -389,13 +389,11 @@ services:
       - bash-history:/root/.bash_history
       - zsh-history:/root/.zsh_history
       - ./shell:/root/custom_shell
-    depends_on:
-      - php-8.5-debug
     networks:
-      - totara     
+      - totara
 
   php-8.5-debug:
-    image: ghcr.io/totara/docker-dev-php85
+    image: ghcr.io/totara/docker-dev-php85-debug
     container_name: totara_php85_debug
     working_dir: ${REMOTE_SRC}
     environment:
@@ -420,6 +418,8 @@ services:
       - ./shell:/root/custom_shell
     networks:
       - totara
+    depends_on:
+      - php-8.5
 
   # php-X.X: ...
   # php-X.X-debug: ...

--- a/php/php84/Dockerfile
+++ b/php/php84/Dockerfile
@@ -96,11 +96,6 @@ RUN pecl channel-update pecl.php.net && \
     &&  docker-php-ext-enable pspell
 
 RUN pecl channel-update pecl.php.net && \
-    pecl install -o -f xdebug-3.4.0 \
-    &&  rm -rf /tmp/pear \
-    &&  docker-php-ext-enable xdebug.so
-
-RUN pecl channel-update pecl.php.net && \
     pecl install -o -f pcov \
     &&  rm -rf /tmp/pear \
     &&  docker-php-ext-enable pcov

--- a/php/php84/Dockerfile-debug
+++ b/php/php84/Dockerfile-debug
@@ -1,0 +1,6 @@
+FROM ghcr.io/totara/docker-dev-php84
+
+RUN pecl channel-update pecl.php.net && \
+    pecl install -o -f xdebug-3.4.7 \
+    &&  rm -rf /tmp/pear \
+    &&  docker-php-ext-enable xdebug.so

--- a/php/php85/Dockerfile
+++ b/php/php85/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         libpspell-dev \
         xmlstarlet \
         libtool \
-        bison 
+        bison
 
 COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
 
@@ -98,11 +98,6 @@ RUN pecl channel-update pecl.php.net && \
     pecl install -o -f pspell \
     &&  rm -rf /tmp/pear \
     &&  docker-php-ext-enable pspell
-
-RUN pecl channel-update pecl.php.net && \
-    pecl install -o -f xdebug-3.5.0 \
-    &&  rm -rf /tmp/pear \
-    &&  docker-php-ext-enable xdebug.so
 
 RUN pecl channel-update pecl.php.net && \
     pecl install -o -f pcov \

--- a/php/php85/Dockerfile-debug
+++ b/php/php85/Dockerfile-debug
@@ -1,0 +1,6 @@
+FROM ghcr.io/totara/docker-dev-php85
+
+RUN pecl channel-update pecl.php.net && \
+    pecl install -o -f xdebug-3.5.1 \
+    &&  rm -rf /tmp/pear \
+    &&  docker-php-ext-enable xdebug.so


### PR DESCRIPTION
### Description

Removes xdebug extension install from normal php-8.4 and php-8.5 containers, and switches dependency around so that php-debug containers depend on standard php containers, rather than vice versa.

Also bumps xdebug version to latest patch releases:

php8.4-debug to xdebug-3.4.7 (to fix segfault issues)
php8.5-debug to xdebug-3.5.1 (to fix Windows performance)

### Testing Instructions

1. Check out this pull request
2. Rebuild php-8.4 and php-8.4-debug containers
3. tup php-8.4
4. Confirm that php-8.4-debug does NOT start at the same time
5. Test using `tzsh php-8.4`:
6. Confirm that `php -i` does not list any xdebug settings
7. Confirm that the unit test `server/totara/notification/tests/webapi_toggle_notifiable_event_v2_test.php` passes without segfault
8. tup php-8.4-debug
9. Test using `tzsh php-8.4-debug`:
10. Confirm that `php -i` shows xdebug configured and enabled
11. Confirm that the unit test `server/totara/notification/tests/webapi_toggle_notifiable_event_v2_test.php` passes without segfault

### Checklist

- [ ] Does what the author says it will do
- [ ] Testing instructions are provided
- [ ] Commit messages make sense and follow the [conventional commit](https://www.conventionalcommits.org) standard
- [ ] No identified security issues
- [ ] No identified maintenance issues
- [ ] Any third-party libraries/dependencies use the MIT or Apache 2.0 license
- [ ] Changes made are backwards compatible and will not break existing setups
- [ ] Changes to scripts in the `bin/` directory run correctly on both MacOS and WSL
- [ ] Changes to containers can be built locally sucessfully (e.g. via `tbuild container && tup container`)
- [ ] Containers/images are compatible with both AMD64 (Windows) and ARM64 (MacOS)
- [ ] Changes made to `config.php` are compatible with our oldest supported Totara version, our newest Totara version, and Moodle
