### PR TITLE
feat: Disabled xdebug in normal PHP 8.4 and 8.5 containers, bumped xdebug versions to latest patch release to fix segfault issue

### DIFF
--- a/compose/php.yml
+++ b/compose/php.yml
@@ -329,6 +329,7 @@ services:
       HIST_FILE: /root/.bash_history
       DISABLE_AUTO_UPDATE: "true" # disables oh-my-zsh update message
       USE_ZSH_NERDFONT: ${USE_ZSH_NERDFONT:-0}
+      XDEBUG_MODE: off
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
@@ -380,6 +381,7 @@ services:
       HIST_FILE: /root/.bash_history
       DISABLE_AUTO_UPDATE: "true" # disables oh-my-zsh update message
       USE_ZSH_NERDFONT: ${USE_ZSH_NERDFONT:-0}
+      XDEBUG_MODE: off
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
@@ -392,7 +394,7 @@ services:
     depends_on:
       - php-8.5-debug
     networks:
-      - totara     
+      - totara
 
   php-8.5-debug:
     image: ghcr.io/totara/docker-dev-php85

--- a/php/php84/Dockerfile
+++ b/php/php84/Dockerfile
@@ -96,7 +96,7 @@ RUN pecl channel-update pecl.php.net && \
     &&  docker-php-ext-enable pspell
 
 RUN pecl channel-update pecl.php.net && \
-    pecl install -o -f xdebug-3.4.0 \
+    pecl install -o -f xdebug-3.4.7 \
     &&  rm -rf /tmp/pear \
     &&  docker-php-ext-enable xdebug.so
 

--- a/php/php85/Dockerfile
+++ b/php/php85/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         libpspell-dev \
         xmlstarlet \
         libtool \
-        bison 
+        bison
 
 COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
 
@@ -100,7 +100,7 @@ RUN pecl channel-update pecl.php.net && \
     &&  docker-php-ext-enable pspell
 
 RUN pecl channel-update pecl.php.net && \
-    pecl install -o -f xdebug-3.5.0 \
+    pecl install -o -f xdebug-3.5.1 \
     &&  rm -rf /tmp/pear \
     &&  docker-php-ext-enable xdebug.so
 


### PR DESCRIPTION
### Description

Sets XDEBUG_MODE env to "off" in normal php-8.4 and php-8.5 containers.

Also bumps xdebug version to latest patch releases:

php8.4-debug to xdebug-3.4.7 (to fix segfault issues)
php8.5-debug to xdebug-3.5.1 (to fix Windows performance)


### Testing Instructions

1. Check out this pull request
2. Rebuild php-8.4 containers
3. tup php-8.4
4. Test using tzsh php-8.4:
5. Confirm `echo $XDEBUG_MODE` is "off"
6. Confirm that the unit test server/totara/notification/tests/webapi_toggle_notifiable_event_v2_test.php passes without segfault, and takes about 10 seconds
7. Test using tzsh php-8.4-debug:
8. Confirm `echo $XDEBUG_MODE` is "develop"
9. Confirm that the unit test server/totara/notification/tests/webapi_toggle_notifiable_event_v2_test.php passes without segfault, and takes about 20 seconds


### Checklist

- [ ] Does what the author says it will do
- [ ] Testing instructions are provided
- [ ] Commit messages make sense and follow the [conventional commit](https://www.conventionalcommits.org) standard
- [ ] No identified security issues
- [ ] No identified maintenance issues
- [ ] Any third-party libraries/dependencies use the MIT or Apache 2.0 license
- [ ] Changes made are backwards compatible and will not break existing setups
- [ ] Changes to scripts in the `bin/` directory run correctly on both MacOS and WSL
- [ ] Changes to containers can be built locally sucessfully (e.g. via `tbuild container && tup container`)
- [ ] Containers/images are compatible with both AMD64 (Windows) and ARM64 (MacOS)
- [ ] Changes made to `config.php` are compatible with our oldest supported Totara version, our newest Totara version, and Moodle
