### PR TITLE
Docker Dev entrypoint for Totara 21 support

### DIFF
--- a/apache/conf.d/server.conf
+++ b/apache/conf.d/server.conf
@@ -22,23 +22,41 @@ RewriteEngine on
 
 DocumentRoot "$REMOTE_SRC"
 
-# Direct php requests to the php-X.X container
-RewriteCond %{HTTP_HOST} totara(\d)(\d)(|\.behat)(|\.localhost)(:[0-9]+)?$
+# Direct php requests to the php-X.X container.
+# Hostname format: [sitename.]totara{major}{minor}[.behat][.debug][.localhost]
+# Apply non-debug first, then override with debug if the host contains .debug.
+RewriteCond %{HTTP_HOST} totara(\d)(\d)(\.behat)?(\.localhost)?(:[0-9]+)?$
 RewriteRule \.php - [H=proxy:fcgi://php-%1.%2:9000]
 
-# Direct xdebug requests to the php-X.X-debug container
-RewriteCond %{HTTP_HOST} totara(\d)(\d)(|\.behat)\.debug(|\.localhost)(:[0-9]+)?$
+# Override: direct Xdebug requests to the php-X.X-debug container
+RewriteCond %{HTTP_HOST} totara(\d)(\d)(\.behat)?\.debug(\.localhost)?(:[0-9]+)?$
 RewriteRule \.php - [H=proxy:fcgi://php-%1.%2-debug:9000]
 
-# Handle if the site name is specified in the host, e.g. sitename.totara73
-RewriteCond %{HTTP_HOST} ^(.+)\.totara(|\.localhost)
-RewriteRule ^(.*)$ - [E=SITENAME:%1]
+# Capture the optional sitename prefix from the hostname.
+# Matches: sitename.totara84, sitename.totara84.localhost, sitename.totara84.debug, etc.
+RewriteCond %{HTTP_HOST} ^([\w-]+)\.totara\d
+RewriteRule ^ - [E=SITENAME:%1]
 
-# If the server directory exists, then rewrite it to use it
+# v21+ (public/ directory exists): route all requests through the front controller.
+# The [H=proxy:...] flag is set here (not only for .php URLs) so that requests like /
+# or static-looking URLs are also processed by PHP-FPM via public/index.php.
+RewriteCond %{HTTP_HOST} totara(\d)(\d)
+RewriteCond %{HTTP_HOST} !\.debug
+RewriteCond %{DOCUMENT_ROOT}/%{ENV:SITENAME}/public/index.php -f
+RewriteRule ^ %{DOCUMENT_ROOT}/%{ENV:SITENAME}/public/index.php [QSA,L,H=proxy:fcgi://php-%1.%2:9000]
+
+# v21+ (debug variant): same but routes to the debug PHP-FPM container
+RewriteCond %{HTTP_HOST} totara(\d)(\d).*\.debug
+RewriteCond %{DOCUMENT_ROOT}/%{ENV:SITENAME}/public/index.php -f
+RewriteRule ^ %{DOCUMENT_ROOT}/%{ENV:SITENAME}/public/index.php [QSA,L,H=proxy:fcgi://php-%1.%2-debug:9000]
+
+# If the server directory exists (version 13 to 20), rewrite to use it
+RewriteCond %{DOCUMENT_ROOT}/%{ENV:SITENAME}/public/index.php !-f
 RewriteCond %{DOCUMENT_ROOT}/%{ENV:SITENAME}/server/version.php -f
 RewriteRule ^(.*)$ %{DOCUMENT_ROOT}/%{ENV:SITENAME}/server$1 [QSA]
 
-# Otherwise don't use the server directory
+# Otherwise (version 12 and older) don't use a subdirectory
+RewriteCond %{DOCUMENT_ROOT}/%{ENV:SITENAME}/public/index.php !-f
 RewriteCond %{DOCUMENT_ROOT}/%{ENV:SITENAME}/server/version.php !-f
 RewriteRule ^(.*)$ %{DOCUMENT_ROOT}/%{ENV:SITENAME}$1 [QSA]
 

--- a/nginx/config/local-server.conf
+++ b/nginx/config/local-server.conf
@@ -1,6 +1,5 @@
 include totara/server.conf;
 
-
 # Here you can define how you want nginx to handle requests made from your local network.
 # You can do whatever you want here.
 
@@ -9,7 +8,11 @@ include totara/server.conf;
 client_max_body_size 1G;
 
 location / {
-    autoindex on;
+    # Redirect non-existing files to index.php for "pretty" URLs
+    # For v21+ installs (public/ webroot), all PHP requests are routed through
+    # public/index.php (the front controller). 
+    # For v13-20 installs the real script exists under server/ and is served directly.
+    try_files $uri $uri/ /index.php?$query_string;
 }
 
 location ~ [^/]\.php(/|$) {
@@ -23,15 +26,24 @@ location ~ [^/]\.php(/|$) {
     fastcgi_split_path_info ^(.+\.php)(/.+)$;
 
     fastcgi_param PATH_INFO       $fastcgi_path_info;
-    fastcgi_param SCRIPT_FILENAME $document_root/$fastcgi_script_name;
     fastcgi_param SCRIPT_NAME     $fastcgi_script_name;
+
+    # For v21+ installs (public/ webroot), route all PHP through the front controller.
+    set $script_filename $document_root$fastcgi_script_name;
+    if ($use_front_controller) {
+        set $script_filename $document_root/index.php;
+    }
+    fastcgi_param SCRIPT_FILENAME $script_filename;
 
     fastcgi_buffers 16 16k;
     fastcgi_buffer_size 32k;
 }
 
-# serve static files directly
+# serve static files directly, fall through to front controller if not found.
+# This is needed for v21+ installs where static assets (amd/build/, pix/, fonts/)
+# live under server/ not public/, so nginx can't serve them directly.
 location ~* ^.+.(jpg|jpeg|gif|css|png|js|ico|html|xml|txt)$ {
     access_log        off;
     expires           max;
+    try_files         $uri /index.php?$query_string;
 }

--- a/nginx/config/remote-server.conf
+++ b/nginx/config/remote-server.conf
@@ -27,14 +27,18 @@ error_page 403 =404 /404.html;
 error_page 501 502 503 =500 /500.html;
 
 location / {
-    try_files $uri $uri/ =404;
+    # Redirect non-existing files to index.php for "pretty" URLs
+    # For v21+ installs (public/ webroot), all PHP requests are routed through
+    # public/index.php (the front controller). 
+    # For v13-20 installs the real script exists under server/ and is served directly.
+    try_files $uri $uri/ /index.php?$query_string;
 }
 
 location ~ ^.*\/(cli|tests|db|classes|amd\/src|rb_sources|yui\/src)\/.*$ {
     deny all;
 }
 
-if (!-f "$document_root/version.php") {
+if (!-f $base_rootdir/server/version.php) {
     # No version.php exists, so the site isn't set up properly or the forwarding host is incorrect
     return 404;
 }
@@ -50,8 +54,14 @@ location ~ [^/]\.php(/|$) {
     fastcgi_split_path_info ^(.+\.php)(/.+)$;
 
     fastcgi_param PATH_INFO       $fastcgi_path_info;
-    fastcgi_param SCRIPT_FILENAME $document_root/$fastcgi_script_name;
     fastcgi_param SCRIPT_NAME     $fastcgi_script_name;
+
+    # For v21+ installs (public/ webroot), route all PHP through the front controller.
+    set $script_filename $document_root$fastcgi_script_name;
+    if ($use_front_controller) {
+        set $script_filename $document_root/index.php;
+    }
+    fastcgi_param SCRIPT_FILENAME $script_filename;
 
     fastcgi_buffers 16 16k;
     fastcgi_buffer_size 32k;

--- a/nginx/config/server.conf
+++ b/nginx/config/server.conf
@@ -25,16 +25,27 @@ if ($debug = "debug") {
 }
 
 # Default root
-set $rootdir "$REMOTE_SRC";
+set $base_rootdir "$REMOTE_SRC";
 
 if ($sitename != "") {
-    set $rootdir "$rootdir/$sitename";
+    set $base_rootdir $base_rootdir/$sitename;
 }
 
+set $use_front_controller 0;
+set $rootdir $base_rootdir;
+
 # If we have the server directory (version 13 and newer) use this as the wwwroot
-if (-f "$rootdir/server/version.php") {
+if (-f "$base_rootdir/server/version.php") {
     # in which case, set that directory as the root
-    set $rootdir "$rootdir/server";
+    set $rootdir $base_rootdir/server;
+}
+
+# If we have the public directory (version 21 and newer) it is a sibling of server/,
+# so check from the original sitename root. Re-check against REMOTE_SRC base.
+# We use a separate variable to avoid double-appending on the server/ branch.
+if (-f $base_rootdir/public/index.php) {
+    set $rootdir $base_rootdir/public;
+    set $use_front_controller 1;
 }
 
 root $rootdir;


### PR DESCRIPTION
### Description

Totara 21 has a new entrypoint, this PR updates nginx & apache so both are supported.


### Testing Instructions

1. TBD...


### Checklist

- [ ] Does what the author says it will do
- [ ] Testing instructions are provided
- [ ] Commit messages make sense and follow the [conventional commit](https://www.conventionalcommits.org) standard
- [ ] No identified security issues
- [ ] No identified maintenance issues
- [ ] Any third-party libraries/dependencies use the MIT or Apache 2.0 license
- [ ] Changes made are backwards compatible and will not break existing setups
- [ ] Changes to scripts in the `bin/` directory run correctly on both MacOS and WSL
- [ ] Changes to containers can be built locally sucessfully (e.g. via `tbuild container && tup container`)
- [ ] Containers/images are compatible with both AMD64 (Windows) and ARM64 (MacOS)
- [ ] Changes made to `config.php` are compatible with our oldest supported Totara version, our newest Totara version, and Moodle
