### PR TITLE
feat: Support subdirectories/behat with front controller

### DIFF
--- a/apache/conf.d/server.conf
+++ b/apache/conf.d/server.conf
@@ -37,6 +37,33 @@ RewriteRule \.php - [H=proxy:fcgi://php-%1.%2-debug:9000]
 RewriteCond %{HTTP_HOST} ^([\w-]+)\.totara\d
 RewriteRule ^ - [E=SITENAME:%1]
 
+# Path-based multisite support (front-controller / v21+ sites only).
+# In addition to the subdomain form (mysite.totara83.localhost/foobar), allow the
+# path form totara83.localhost/mysite/foobar. This only applies when no sitename was
+# supplied as a subdomain; capture the first path segment as the candidate site.
+# Unlike the subdomain form, the /<site> prefix stays in the request URI so that
+# SCRIPT_NAME keeps the /<site> prefix once the request reaches the front controller.
+RewriteCond %{ENV:SITENAME} ^$
+RewriteCond %{REQUEST_URI} ^/([\w-]+)
+RewriteRule ^ - [E=PATHSITE:%1]
+
+# v21+ front controller (path form): totara83.localhost/mysite/foobar.
+# Checked before the subdomain form below so a real path-based site takes precedence
+# over the base site's own front controller. Only matches when the candidate site has
+# a public/ webroot (front-controller / v21+ install). The host condition that captures
+# the php version is kept last so its %1.%2 backrefs survive into the RewriteRule.
+RewriteCond %{HTTP_HOST} !\.debug
+RewriteCond %{ENV:PATHSITE} ^.+$
+RewriteCond %{DOCUMENT_ROOT}/%{ENV:PATHSITE}/public/index.php -f
+RewriteCond %{HTTP_HOST} totara(\d)(\d)
+RewriteRule ^ %{DOCUMENT_ROOT}/%{ENV:PATHSITE}/public/index.php [QSA,L,H=proxy:fcgi://php-%1.%2:9000]
+
+# v21+ front controller (path form, debug variant): routes to the debug PHP-FPM container
+RewriteCond %{ENV:PATHSITE} ^.+$
+RewriteCond %{DOCUMENT_ROOT}/%{ENV:PATHSITE}/public/index.php -f
+RewriteCond %{HTTP_HOST} totara(\d)(\d).*\.debug
+RewriteRule ^ %{DOCUMENT_ROOT}/%{ENV:PATHSITE}/public/index.php [QSA,L,H=proxy:fcgi://php-%1.%2-debug:9000]
+
 # v21+ (public/ directory exists): route all requests through the front controller.
 # The [H=proxy:...] flag is set here (not only for .php URLs) so that requests like /
 # or static-looking URLs are also processed by PHP-FPM via public/index.php.

--- a/nginx/config/local-server.conf
+++ b/nginx/config/local-server.conf
@@ -8,11 +8,13 @@ include totara/server.conf;
 client_max_body_size 1G;
 
 location / {
-    # Redirect non-existing files to index.php for "pretty" URLs
+    # Redirect non-existing files to the front controller for "pretty" URLs.
     # For v21+ installs (public/ webroot), all PHP requests are routed through
-    # public/index.php (the front controller). 
+    # public/index.php (the front controller).
     # For v13-20 installs the real script exists under server/ and is served directly.
-    try_files $uri $uri/ /index.php?$query_string;
+    # $front_controller is /index.php normally, or /<site>/index.php for path-based
+    # sites (see server.conf) so SCRIPT_NAME keeps the /<site> prefix.
+    try_files $uri $uri/ $front_controller?$query_string;
 }
 
 location ~ [^/]\.php(/|$) {
@@ -45,5 +47,5 @@ location ~ [^/]\.php(/|$) {
 location ~* ^.+.(jpg|jpeg|gif|css|png|js|ico|html|xml|txt)$ {
     access_log        off;
     expires           max;
-    try_files         $uri /index.php?$query_string;
+    try_files         $uri $front_controller?$query_string;
 }

--- a/nginx/config/server.conf
+++ b/nginx/config/server.conf
@@ -31,6 +31,27 @@ if ($sitename != "") {
     set $base_rootdir $base_rootdir/$sitename;
 }
 
+# Path-based multisite support (front-controller / v21+ sites only).
+# In addition to the subdomain form (mysite.totara83.localhost/foobar), allow the
+# path form totara83.localhost/mysite/foobar.
+set $path_site "";
+if ($request_uri ~ "^/([\w-]+)") {
+    set $path_site $1;
+}
+# The front controller URI used as the try_files fallback for "pretty"/modern-routed
+# URLs that don't map to a real file. For path-based sites it must include the /<site>
+# prefix so that, after the internal redirect, SCRIPT_NAME becomes /<site>/index.php
+# rather than /index.php.
+set $front_controller "/index.php";
+set $path_route "${sitename}::";
+if (-f "$REMOTE_SRC/$path_site/public/index.php") {
+    set $path_route "${sitename}::fc";
+}
+if ($path_route = "::fc") {
+    set $base_rootdir "$REMOTE_SRC/$path_site";
+    set $front_controller "/$path_site/index.php";
+}
+
 set $use_front_controller 0;
 set $rootdir $base_rootdir;
 

--- a/php/includes/config-after.php
+++ b/php/includes/config-after.php
@@ -64,7 +64,7 @@ if ($DOCKER_DEV->xdebug_enabled) {
 if ($DOCKER_DEV->is_multi_site) {
     $CFG->behat_wwwroot .= '/' . $DOCKER_DEV->site_name;
 }
-if ($DOCKER_DEV->has_server_dir) {
+if ($DOCKER_DEV->has_server_dir && !$DOCKER_DEV->has_front_controller) {
     $CFG->behat_wwwroot .= '/server';
 }
 
@@ -269,7 +269,10 @@ if (!empty($_SERVER['HTTP_X_FORWARDED_HOST']) && preg_match($ngrok_hostname_rege
 
     if ($DOCKER_DEV->is_multi_site && strpos($hostname, $DOCKER_DEV->site_name) === false) {
         $CFG->wwwroot .= '/' . $DOCKER_DEV->site_name;
-        if ($DOCKER_DEV->has_server_dir) {
+        // Front-controller sites (v21+) serve from public/ and strip the /<site> base
+        // path themselves, so /server must not be part of the wwwroot. Only legacy sites
+        // (server/ webroot, no front controller) are served under /<site>/server.
+        if ($DOCKER_DEV->has_server_dir && !$DOCKER_DEV->has_front_controller) {
             $CFG->wwwroot .= '/server';
         }
     }

--- a/php/includes/config-before.php
+++ b/php/includes/config-before.php
@@ -5,6 +5,7 @@
 
 // Docker-dev specific variable setup
 $DOCKER_DEV->has_server_dir = file_exists($DOCKER_DEV->dir . '/server/config.php');
+$DOCKER_DEV->has_front_controller = file_exists($DOCKER_DEV->dir . '/public/index.php');
 $DOCKER_DEV->is_multi_site = $DOCKER_DEV->dir !== '/var/www/totara/src';
 $DOCKER_DEV->site_name = $DOCKER_DEV->is_multi_site ? basename($DOCKER_DEV->dir) : 'totara';
 


### PR DESCRIPTION
### Description

Describe what this pull request is about


### Testing Instructions

1. Check out this pull request
2. In the routing branch and a regular branch (e.g. main), try the following:
3. Use the URL regularly (e.g. mysite.totara84.localhost)
4. Use the directory-based URL (e.g. totara84.localhost/mysite)
5. Run a behat test. It shouldn't fail with an error about the site not being set up for testing


### Checklist

- [x] Does what the author says it will do
- [x] Testing instructions are provided
- [x] Commit messages make sense and follow the [conventional commit](https://www.conventionalcommits.org) standard
- [ ] No identified security issues
- [ ] No identified maintenance issues
- [ ] Any third-party libraries/dependencies use the MIT or Apache 2.0 license
- [ ] Changes made are backwards compatible and will not break existing setups
- [ ] Changes to scripts in the `bin/` directory run correctly on both MacOS and WSL
- [ ] Changes to containers can be built locally sucessfully (e.g. via `tbuild container && tup container`)
- [ ] Containers/images are compatible with both AMD64 (Windows) and ARM64 (MacOS)
- [ ] Changes made to `config.php` are compatible with our oldest supported Totara version, our newest Totara version, and Moodle
