### PR TITLE
feat: Add container for viewing OpenTelemetry data

### DIFF
--- a/bin/tdocker
+++ b/bin/tdocker
@@ -15,6 +15,7 @@ files=(
     "compose/mssql.yml"
     "compose/mysql.yml"
     "compose/nginx.yml"
+    "compose/otel-lgtm.yml"
     "compose/pgsql.yml"
     "compose/php.yml"
     "compose/php-legacy.yml"

--- a/compose/otel-lgtm.yml
+++ b/compose/otel-lgtm.yml
@@ -1,0 +1,20 @@
+services:
+
+  # Grafana OTel-LGTM all-in-one: OTel Collector + Loki (logs) + Tempo (traces) + Mimir (metrics),
+  # for OpenTelemetry development. Start it with 'tup otel-lgtm'.
+  # Point Totara at it via the telemetry collector endpoint setting: http://otel-lgtm:4318
+  # The Grafana UI is available on the host at http://localhost:3000 (view logs via Explore > Loki).
+  otel-lgtm:
+    image: grafana/otel-lgtm:0.30.0
+    container_name: totara_otel_lgtm
+    restart: ${RESTART_POLICY:-no}
+    environment:
+      TZ: ${TIME_ZONE}
+    ports:
+      # Grafana UI.
+      - "3000:3000"
+      # OTLP/HTTP ingest, published to the host for scripts running outside docker.
+      # Containers on the totara network should use http://otel-lgtm:4318 instead.
+      - "4318:4318"
+    networks:
+      - totara


### PR DESCRIPTION
### Description
Adds an opt-in Jaeger v2 all-in-one container for local OpenTelemetry development:                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                      
  - `compose/jaeger.yml` - new service `jaeger` (`jaegertracing/jaeger:2.20.0`, pinned): OTLP/HTTP trace ingest on port 4318, trace UI on http://localhost:16686, in-memory storage only, joined to the `totara` network.                                                                                                                                                                                                                                                           
  - `bin/tdocker` — registers the new compose file in the `files` array.                 

Nothing starts by default - developers opt in with `tup jaeger` (or by adding `jaeger` to `DEFAULT_CONTAINERS`). Sites/scripts inside docker export traces to `http://jaeger:4318`; from the host use `http://localhost:4318`. 

### Testing Instructions
1. Check out this pull request
2. Run `tdocker config --services | grep jaeger` - the service resolves
3. Run `tup jaeger` — the `totara_jaeger` container starts
4. Run `curl -s -X POST -H 'Content-Type: application/json' -d '{"resourceSpans":[]}' http://localhost:4318/v1/traces` - expect `{"partialSuccess":{}}`
5. Open http://localhost:16686 — the Jaeger UI loads
6. Optional end-to-end: export a span from any OTLP client inside docker to `http://jaeger:4318` and find it in the UI (verified with the OpenTelemetry PHP SDK from a php-8.4 container)


### Checklist

- [x] Does what the author says it will do
- [x] Testing instructions are provided
- [x] Commit messages make sense and follow the [conventional commit](https://www.conventionalcommits.org) standard
- [x] No identified security issues
- [x] No identified maintenance issues
- [x] Any third-party libraries/dependencies use the MIT or Apache 2.0 license
- [x] Changes made are backwards compatible and will not break existing setups
- [ ] Changes to scripts in the `bin/` directory run correctly on both MacOS and WSL
- [x] Changes to containers can be built locally sucessfully (e.g. via `tbuild container && tup container`)
- [x] Containers/images are compatible with both AMD64 (Windows) and ARM64 (MacOS)
- [x] Changes made to `config.php` are compatible with our oldest supported Totara version, our newest Totara version, and Moodle

### Note:
Did not test WSL, a tester should do that
