### PR TITLE
feat: Add OpenTelemetry in php-8.4 and php-8.5 image

### DIFF
--- a/php/php84/Dockerfile
+++ b/php/php84/Dockerfile
@@ -105,6 +105,11 @@ RUN pecl channel-update pecl.php.net && \
     &&  rm -rf /tmp/pear \
     &&  docker-php-ext-enable pcov
 
+RUN pecl channel-update pecl.php.net && \
+    pecl install -o -f opentelemetry && \
+    rm -rf /tmp/pear && \
+    docker-php-ext-enable opentelemetry.so
+
 # Install composer
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 

--- a/php/php85/Dockerfile
+++ b/php/php85/Dockerfile
@@ -109,6 +109,11 @@ RUN pecl channel-update pecl.php.net && \
     &&  rm -rf /tmp/pear \
     &&  docker-php-ext-enable pcov
 
+RUN pecl channel-update pecl.php.net && \
+    pecl install -o -f opentelemetry && \
+    rm -rf /tmp/pear && \
+    docker-php-ext-enable opentelemetry.so
+
 # Install composer
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 


### PR DESCRIPTION
### Description

Add OpenTelemetry in php-8.4 and php-8.5 image


### Testing Instructions

1. Check out this pull request
2. Rebuild imamge of php-8.4 and php-8.5
3. Make sure no error when build images and tup those images


### Checklist

- [ ] Does what the author says it will do
- [ ] Testing instructions are provided
- [ ] Commit messages make sense and follow the [conventional commit](https://www.conventionalcommits.org) standard
- [ ] No identified security issues
- [ ] No identified maintenance issues
- [ ] Any third-party libraries/dependencies use the MIT or Apache 2.0 license
- [ ] Changes made are backwards compatible and will not break existing setups
- [ ] Changes to scripts in the `bin/` directory run correctly on both MacOS and WSL
- [ ] Changes to containers can be built locally sucessfully (e.g. via `tbuild container && tup container`)
- [ ] Containers/images are compatible with both AMD64 (Windows) and ARM64 (MacOS)
- [ ] Changes made to `config.php` are compatible with our oldest supported Totara version, our newest Totara version, and Moodle
