### PR TITLE
feat: add images and settings to create primary-replica PostgreSQL

### DIFF
--- a/bin/tdocker
+++ b/bin/tdocker
@@ -16,6 +16,7 @@ files=(
     "compose/mysql.yml"
     "compose/nginx.yml"
     "compose/pgsql.yml"
+    "compose/pgsql-replication.yml"
     "compose/php.yml"
     "compose/php-legacy.yml"
     "compose/selenium.yml"

--- a/compose/pgsql-replication.yml
+++ b/compose/pgsql-replication.yml
@@ -1,0 +1,48 @@
+services:
+  
+  pgsql-primary:
+    image: postgres:16-alpine
+    container_name: totara_pgsql-primary
+    ports:
+      - "54320:5432"
+    environment:
+      TZ: ${TIME_ZONE}
+      PGDATA: /var/lib/postgresql/data/pgdata
+      POSTGRES_HOST_AUTH_METHOD: trust
+    command:
+      - postgres
+      - -c
+      - config_file=/etc/postgresql/postgresql.conf
+    volumes:
+      - ./pgsql/my-postgres-master.conf:/etc/postgresql/postgresql.conf
+      - ./pgsql/my-postgres-hba.conf:/etc/postgresql/pg_hba.conf
+      - ./pgsql/init:/docker-entrypoint-initdb.d
+      - pgsql16-master-data:/var/lib/postgresql/data
+    depends_on:
+      - nginx
+    networks:
+      - totara
+
+  pgsql-replica-1:
+    image: postgres:16-alpine
+    container_name: totara_pgsql-replica-1
+    ports:
+      - "54321:5432"
+    environment:
+      TZ: ${TIME_ZONE}
+      PGDATA: /var/lib/postgresql/data/pgdata
+      POSTGRES_HOST_AUTH_METHOD: trust
+    entrypoint:
+      - /usr/local/bin/replica-entrypoint.sh
+    volumes:
+      - ./pgsql/my-postgres.conf:/etc/postgresql/postgresql.conf
+      - ./pgsql/replica-entrypoint.sh:/usr/local/bin/replica-entrypoint.sh
+      - pgsql16-replica-data-1:/var/lib/postgresql/data
+    depends_on:
+      - pgsql-primary
+    networks:
+      - totara
+
+volumes:
+  pgsql16-master-data:
+  pgsql16-replica-data-1:

--- a/pgsql/init/creare-replicator.sql
+++ b/pgsql/init/creare-replicator.sql
@@ -1,0 +1,4 @@
+CREATE ROLE replicator
+WITH REPLICATION
+LOGIN
+PASSWORD 'replica_password';

--- a/pgsql/my-postgres-hba.conf
+++ b/pgsql/my-postgres-hba.conf
@@ -1,0 +1,13 @@
+# "local" is for Unix domain socket connections only
+local   all             all                                     trust
+# IPv4 local connections:
+host    all             all             127.0.0.1/32            trust
+# IPv6 local connections:
+host    all             all             ::1/128                 trust
+# TYPE  DATABASE     USER           ADDRESS           METHOD
+host    replication  replicator     0.0.0.0/0         scram-sha-256
+# Dev-only: allow connections from the host and other containers on the
+# docker network. Mirrors POSTGRES_HOST_AUTH_METHOD=trust, which the
+# mounted hba_file would otherwise override.
+host    all          all            0.0.0.0/0         trust
+host    all          all            ::/0              trust

--- a/pgsql/my-postgres-master.conf
+++ b/pgsql/my-postgres-master.conf
@@ -1,0 +1,6 @@
+listen_addresses = '*'
+wal_level = replica
+max_wal_senders = 10
+max_replication_slots = 10
+hot_standby = on
+hba_file = '/etc/postgresql/pg_hba.conf'

--- a/pgsql/replica-entrypoint.sh
+++ b/pgsql/replica-entrypoint.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+set -e
+
+PRIMARY_HOST=pgsql-primary
+REPLICATION_USER=replicator
+PGDATA=${PGDATA:-/var/lib/postgresql/data}
+
+if [ ! -f "$PGDATA/PG_VERSION" ]; then
+    echo "Initializing replica..."
+
+    until pg_isready -h "$PRIMARY_HOST" -U "$REPLICATION_USER"
+    do
+        sleep 2
+    done
+
+    rm -rf "$PGDATA"/*
+
+    export PGPASSWORD=replica_password
+
+    pg_basebackup \
+        -h "$PRIMARY_HOST" \
+        -U "$REPLICATION_USER" \
+        -D "$PGDATA" \
+        -R \
+        -Fp \
+        -Xs \
+        -P
+fi
+
+exec docker-entrypoint.sh postgres \
+    -c config_file=/etc/postgresql/postgresql.conf


### PR DESCRIPTION
### Description

Describe what this pull request is about


### Testing Instructions

1. Check out this pull request
2. Run the script  `tup pgsql-primary pgsql-replica-1` 
3. Make sure totara_pgsql_primary and totara_pgsql_replica_1 is running (easy way to check is open the UI of Rancher Desktop, in Containers tab)
4. change db setting in `config.php` 
```
$CFG->dbhost = 'pgsql-primary'; 
$CFG->dbtype = 'pgsql';
$CFG->dbuser = 'postgres';
$CFG->dbpass = '';
```
And extra setting at the end of `config.php`
```
$CFG->dboptions['readonly'] = [
    'instance' => ['pgsql-replica-1'],   // replica HOST(s);
    'connecttimeout' => 2,              // optional, seconds, default 2
    'latency' => 0.5,                   // optional, seconds, DEFAULT 1 when omitted
    // 'exclude_tables' => ['config'], // optional, emergency use
];
```

### Checklist

- [ ] Does what the author says it will do
- [ ] Testing instructions are provided
- [ ] Commit messages make sense and follow the [conventional commit](https://www.conventionalcommits.org) standard
- [ ] No identified security issues
- [ ] No identified maintenance issues
- [ ] Any third-party libraries/dependencies use the MIT or Apache 2.0 license
- [ ] Changes made are backwards compatible and will not break existing setups
- [ ] Changes to scripts in the `bin/` directory run correctly on both MacOS and WSL
- [ ] Changes to containers can be built locally sucessfully (e.g. via `tbuild container && tup container`)
- [ ] Containers/images are compatible with both AMD64 (Windows) and ARM64 (MacOS)
- [ ] Changes made to `config.php` are compatible with our oldest supported Totara version, our newest Totara version, and Moodle
