### PR TITLE
feat: Add grafana container for viewing OpenTelemetry data

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -63,3 +63,12 @@ REMOTE_SRC=/var/www/totara/src
 REMOTE_DATA=/var/www/totara/data
 MYSQL_ROOT_PW=root
 MSSQL_SA_PW=Totara.Mssql1
+
+# OpenTelemetry export from the PHP 8.4/8.5 containers (opt-in).
+# Start the backend with 'tup otel-lgtm' (Grafana UI: http://localhost:3000), then uncomment:
+#OTEL_PHP_AUTOLOAD_ENABLED=true
+#OTEL_SERVICE_NAME=totara
+#OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-lgtm:4318
+#OTEL_TRACES_EXPORTER=otlp
+#OTEL_LOGS_EXPORTER=otlp
+#OTEL_METRICS_EXPORTER=otlp

--- a/bin/tdocker
+++ b/bin/tdocker
@@ -15,6 +15,7 @@ files=(
     "compose/mssql.yml"
     "compose/mysql.yml"
     "compose/nginx.yml"
+    "compose/otel-lgtm.yml"
     "compose/pgsql.yml"
     "compose/php.yml"
     "compose/php-legacy.yml"

--- a/compose/otel-lgtm.yml
+++ b/compose/otel-lgtm.yml
@@ -1,0 +1,20 @@
+services:
+
+  # Grafana OTel-LGTM all-in-one: OTel Collector + Loki (logs) + Tempo (traces) + Mimir (metrics),
+  # for OpenTelemetry development. Start it with 'tup otel-lgtm'.
+  # Point Totara at it via the telemetry collector endpoint setting: http://otel-lgtm:4318
+  # The Grafana UI is available on the host at http://localhost:3000 (view logs via Explore > Loki).
+  otel-lgtm:
+    image: grafana/otel-lgtm:0.30.0
+    container_name: totara_otel_lgtm
+    restart: ${RESTART_POLICY:-no}
+    environment:
+      TZ: ${TIME_ZONE}
+    ports:
+      # Grafana UI.
+      - "3000:3000"
+      # OTLP/HTTP ingest, published to the host for scripts running outside docker.
+      # Containers on the totara network should use http://otel-lgtm:4318 instead.
+      - "4318:4318"
+    networks:
+      - totara

--- a/compose/php.yml
+++ b/compose/php.yml
@@ -330,6 +330,13 @@ services:
       DISABLE_AUTO_UPDATE: "true" # disables oh-my-zsh update message
       USE_ZSH_NERDFONT: ${USE_ZSH_NERDFONT:-0}
       XDEBUG_MODE: off
+      # OpenTelemetry export (opt-in): set the OTEL_* values in your .env file, see .env.dist.
+      OTEL_PHP_AUTOLOAD_ENABLED: ${OTEL_PHP_AUTOLOAD_ENABLED:-}
+      OTEL_SERVICE_NAME: ${OTEL_SERVICE_NAME:-}
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
+      OTEL_TRACES_EXPORTER: ${OTEL_TRACES_EXPORTER:-}
+      OTEL_LOGS_EXPORTER: ${OTEL_LOGS_EXPORTER:-}
+      OTEL_METRICS_EXPORTER: ${OTEL_METRICS_EXPORTER:-}
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
@@ -359,6 +366,13 @@ services:
       HIST_FILE: /root/.bash_history
       DISABLE_AUTO_UPDATE: "true" # disables oh-my-zsh update message
       USE_ZSH_NERDFONT: ${USE_ZSH_NERDFONT:-0}
+      # OpenTelemetry export (opt-in): set the OTEL_* values in your .env file, see .env.dist.
+      OTEL_PHP_AUTOLOAD_ENABLED: ${OTEL_PHP_AUTOLOAD_ENABLED:-}
+      OTEL_SERVICE_NAME: ${OTEL_SERVICE_NAME:-}
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
+      OTEL_TRACES_EXPORTER: ${OTEL_TRACES_EXPORTER:-}
+      OTEL_LOGS_EXPORTER: ${OTEL_LOGS_EXPORTER:-}
+      OTEL_METRICS_EXPORTER: ${OTEL_METRICS_EXPORTER:-}
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
@@ -382,6 +396,13 @@ services:
       DISABLE_AUTO_UPDATE: "true" # disables oh-my-zsh update message
       USE_ZSH_NERDFONT: ${USE_ZSH_NERDFONT:-0}
       XDEBUG_MODE: off
+      # OpenTelemetry export (opt-in): set the OTEL_* values in your .env file, see .env.dist.
+      OTEL_PHP_AUTOLOAD_ENABLED: ${OTEL_PHP_AUTOLOAD_ENABLED:-}
+      OTEL_SERVICE_NAME: ${OTEL_SERVICE_NAME:-}
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
+      OTEL_TRACES_EXPORTER: ${OTEL_TRACES_EXPORTER:-}
+      OTEL_LOGS_EXPORTER: ${OTEL_LOGS_EXPORTER:-}
+      OTEL_METRICS_EXPORTER: ${OTEL_METRICS_EXPORTER:-}
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}
@@ -411,6 +432,13 @@ services:
       HIST_FILE: /root/.bash_history
       DISABLE_AUTO_UPDATE: "true" # disables oh-my-zsh update message
       USE_ZSH_NERDFONT: ${USE_ZSH_NERDFONT:-0}
+      # OpenTelemetry export (opt-in): set the OTEL_* values in your .env file, see .env.dist.
+      OTEL_PHP_AUTOLOAD_ENABLED: ${OTEL_PHP_AUTOLOAD_ENABLED:-}
+      OTEL_SERVICE_NAME: ${OTEL_SERVICE_NAME:-}
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
+      OTEL_TRACES_EXPORTER: ${OTEL_TRACES_EXPORTER:-}
+      OTEL_LOGS_EXPORTER: ${OTEL_LOGS_EXPORTER:-}
+      OTEL_METRICS_EXPORTER: ${OTEL_METRICS_EXPORTER:-}
     volumes:
       - ${LOCAL_SRC}:${REMOTE_SRC}
       - totara-data:${REMOTE_DATA}


### PR DESCRIPTION
### Description
Adds an opt-in Grafana OTel-LGTM all-in-one container for local OpenTelemetry development, and wires the producer side so the PHP containers can export to it:

- `compose/otel-lgtm.yml` - new service `otel-lgtm` (`grafana/otel-lgtm:0.30.0`, pinned): OTel Collector with OTLP/HTTP ingest on port 4318 accepting all three signals - traces (Tempo), logs (Loki) and metrics (Prometheus/Mimir) - with the Grafana UI on http://localhost:3000. Joined to the `totara` network.
- `bin/tdocker` - registers the new compose file in the `files` array.
- `compose/php.yml` - passes the six `OTEL_*` environment variables through to the `php-8.4`, `php-8.4-debug`, `php-8.5` and `php-8.5-debug` services, each with an empty default so telemetry stays completely inert until a developer opts in.
- `.env.dist` - documents the opt-in block (`OTEL_PHP_AUTOLOAD_ENABLED`, `OTEL_SERVICE_NAME`, `OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-lgtm:4318`, and the three `*_EXPORTER=otlp` values).

Nothing starts or exports by default - developers opt in with `tup otel-lgtm` plus uncommenting the OTEL block in their `.env`. Containers on the totara network export to `http://otel-lgtm:4318`; from the host use `http://localhost:4318`.

### Testing Instructions
1. Check out this pull request
2. Run `tdocker config --services | grep otel` - the service resolves
3. Run `tup otel-lgtm` - the `totara_otel_lgtm` container starts (first boot takes ~20s)
4. Run `curl -s -X POST -H 'Content-Type: application/json' -d '{"resourceSpans":[]}' http://localhost:4318/v1/traces` - expect `{"partialSuccess":{}}`
5. Open http://localhost:3000 - the Grafana UI loads
6. Uncomment the OTEL block in your `.env` (values from `.env.dist`), then `tup php` from a t21 site so the container is recreated with the new environment (a plain restart is not enough)
7. Browse the site / trigger an error, then in Grafana Explore check each signal: Tempo (traces, including `db SELECT` spans), Loki (log records, query `{service_name="totara"}`), Prometheus (metrics - note OTLP gauge names gain a `_ratio` suffix for unit "1")
8. Comment the OTEL block out again and `tup php` - telemetry is inert (SDK returns no-op providers)

Verified end-to-end with the OpenTelemetry PHP SDK from a php-8.4 container: root + DB spans in Tempo, error/notice log records (trace-correlated) in Loki, gauge value in Prometheus.

### Checklist

- [x] Does what the author says it will do
- [x] Testing instructions are provided
- [x] Commit messages make sense and follow the [conventional commit](https://www.conventionalcommits.org) standard
- [x] No identified security issues
- [x] No identified maintenance issues
- [ ] Any third-party libraries/dependencies use the MIT or Apache 2.0 license (see licensing note below)
- [x] Changes made are backwards compatible and will not break existing setups (all OTEL_* defaults are empty; nothing starts by default)
- [x] Changes to scripts in the `bin/` directory run correctly on both MacOS and WSL (one literal entry in the `files` array; verified on MacOS)
- [x] Changes to containers can be built locally sucessfully (no build step - upstream image is pulled; verified via `tup otel-lgtm`)
- [x] Containers/images are compatible with both AMD64 (Windows) and ARM64 (MacOS) (Docker Hub manifest for `grafana/otel-lgtm:0.30.0` includes linux/amd64 and linux/arm64; ran on ARM64 locally)
- [x] Changes made to `config.php` are compatible with our oldest supported Totara version, our newest Totara version, and Moodle (`config.php` is not touched)

### Notes:
- Licensing: the OTel Collector and Prometheus components are Apache-2.0, but Grafana/Loki/Tempo are AGPL-3.0. They run as standalone services in a local dev container only - nothing is linked into or distributed with the product - so this is a usage question rather than a code-licensing one, but flagging it since the checklist wording is MIT/Apache-only.
- Did not test WSL, a tester should do that
