### PR TITLE
fix: Retry failed apt package downloads when building the PHP images

### DIFF
--- a/php/php73/Dockerfile
+++ b/php/php73/Dockerfile
@@ -2,6 +2,10 @@ FROM php:7.3-fpm-bullseye
 
 ARG TIME_ZONE=Pacific/Auckland
 
+# apt does not retry failed downloads, so a single timed out .deb from the Debian CDN fails
+# the whole build. Older suites go cold in the CDN more often, but any suite can time out.
+RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries
+
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         apt-transport-https \
         libgd3 \

--- a/php/php74/Dockerfile
+++ b/php/php74/Dockerfile
@@ -2,6 +2,10 @@ FROM php:7.4-fpm-bullseye
 
 ARG TIME_ZONE=Pacific/Auckland
 
+# apt does not retry failed downloads, so a single timed out .deb from the Debian CDN fails
+# the whole build. Older suites go cold in the CDN more often, but any suite can time out.
+RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries
+
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         apt-transport-https \
         libfreetype6-dev \

--- a/php/php80/Dockerfile
+++ b/php/php80/Dockerfile
@@ -2,6 +2,10 @@ FROM php:8.0-fpm-bullseye
 
 ARG TIME_ZONE=Pacific/Auckland
 
+# apt does not retry failed downloads, so a single timed out .deb from the Debian CDN fails
+# the whole build. Older suites go cold in the CDN more often, but any suite can time out.
+RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries
+
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         apt-transport-https \
         libfreetype6-dev \

--- a/php/php81/Dockerfile
+++ b/php/php81/Dockerfile
@@ -2,6 +2,10 @@ FROM php:8.1-fpm-bookworm
 
 ARG TIME_ZONE=Pacific/Auckland
 
+# apt does not retry failed downloads, so a single timed out .deb from the Debian CDN fails
+# the whole build. Older suites go cold in the CDN more often, but any suite can time out.
+RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries
+
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         apt-transport-https \
         libfreetype6-dev \

--- a/php/php82/Dockerfile
+++ b/php/php82/Dockerfile
@@ -2,6 +2,10 @@ FROM php:8.2-fpm-bookworm
 
 ARG TIME_ZONE=Pacific/Auckland
 
+# apt does not retry failed downloads, so a single timed out .deb from the Debian CDN fails
+# the whole build. Older suites go cold in the CDN more often, but any suite can time out.
+RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries
+
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         apt-transport-https \
         libfreetype6-dev \

--- a/php/php83/Dockerfile
+++ b/php/php83/Dockerfile
@@ -2,6 +2,10 @@ FROM php:8.3-fpm-bookworm
 
 ARG TIME_ZONE=Pacific/Auckland
 
+# apt does not retry failed downloads, so a single timed out .deb from the Debian CDN fails
+# the whole build. Older suites go cold in the CDN more often, but any suite can time out.
+RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries
+
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         apt-transport-https \
         libfreetype6-dev \

--- a/php/php84/Dockerfile
+++ b/php/php84/Dockerfile
@@ -2,6 +2,10 @@ FROM php:8.4-fpm-bookworm
 
 ARG TIME_ZONE=Pacific/Auckland
 
+# apt does not retry failed downloads, so a single timed out .deb from the Debian CDN fails
+# the whole build. Older suites go cold in the CDN more often, but any suite can time out.
+RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries
+
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         apt-transport-https \
         libfreetype6-dev \

--- a/php/php85/Dockerfile
+++ b/php/php85/Dockerfile
@@ -2,6 +2,10 @@ FROM php:8.5.2-fpm-bookworm
 
 ARG TIME_ZONE=Pacific/Auckland
 
+# apt does not retry failed downloads, so a single timed out .deb from the Debian CDN fails
+# the whole build. Older suites go cold in the CDN more often, but any suite can time out.
+RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries
+
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         apt-transport-https \
         libfreetype6-dev \


### PR DESCRIPTION
### Description

Fixes #409

### Testing Instructions

1. Confirm the builds run - and check if a timeout occurred during one


### Checklist

- [ ] Does what the author says it will do
- [ ] Testing instructions are provided
- [x] Commit messages make sense and follow the [conventional commit](https://www.conventionalcommits.org) standard
- [x] No identified security issues
- [x] No identified maintenance issues
- [ ] Any third-party libraries/dependencies use the MIT or Apache 2.0 license
- [x] Changes made are backwards compatible and will not break existing setups
- [ ] Changes to scripts in the `bin/` directory run correctly on both MacOS and WSL
- [ ] Changes to containers can be built locally sucessfully (e.g. via `tbuild container && tup container`)
- [x] Containers/images are compatible with both AMD64 (Windows) and ARM64 (MacOS)
- [ ] Changes made to `config.php` are compatible with our oldest supported Totara version, our newest Totara version, and Moodle
